### PR TITLE
fix: typeguard doesnt exist on lower pythons

### DIFF
--- a/build/__native_bce0bfc64ce5e845ec4a.c
+++ b/build/__native_bce0bfc64ce5e845ec4a.c
@@ -1117,7 +1117,7 @@ CPyL4: ;
 CPyL5: ;
     CPy_INCREF(cpy_r_match);
     cpy_r_r15 = cpy_r_match;
-    cpy_r_r16 = CPyStatics[319]; /* 1 */
+    cpy_r_r16 = CPyStatics[320]; /* 1 */
     cpy_r_r17 = PyObject_GetItem(cpy_r_r15, cpy_r_r16);
     CPy_DECREF(cpy_r_r15);
     if (unlikely(cpy_r_r17 == NULL)) {
@@ -1126,7 +1126,7 @@ CPyL5: ;
     }
     cpy_r_r18 = cpy_r_r17;
     cpy_r_r19 = cpy_r_match;
-    cpy_r_r20 = CPyStatics[320]; /* 2 */
+    cpy_r_r20 = CPyStatics[321]; /* 2 */
     cpy_r_r21 = PyObject_GetItem(cpy_r_r19, cpy_r_r20);
     CPy_DECREF(cpy_r_r19);
     if (unlikely(cpy_r_r21 == NULL)) {
@@ -1956,7 +1956,7 @@ PyObject *CPyDef_abi___abi_to_signature(PyObject *cpy_r_abi_element) {
         CPy_AddTraceback("faster_eth_utils/abi.py", "abi_to_signature", 202, CPyStatic_abi___globals);
         goto CPyL21;
     }
-    cpy_r_r5 = CPyStatics[392]; /* frozenset({'fallback', 'receive'}) */
+    cpy_r_r5 = CPyStatics[394]; /* frozenset({'receive', 'fallback'}) */
     cpy_r_r6 = PySet_Contains(cpy_r_r5, cpy_r_r4);
     cpy_r_r7 = cpy_r_r6 >= 0;
     if (unlikely(!cpy_r_r7)) {
@@ -1969,7 +1969,7 @@ PyObject *CPyDef_abi___abi_to_signature(PyObject *cpy_r_abi_element) {
     cpy_r_r10 = CPyStatics[38]; /* 'format' */
     PyObject *cpy_r_r11[3] = {cpy_r_r0, cpy_r_r4, cpy_r_r9};
     cpy_r_r12 = (PyObject **)&cpy_r_r11;
-    cpy_r_r13 = CPyStatics[334]; /* ('name', 'input_types') */
+    cpy_r_r13 = CPyStatics[335]; /* ('name', 'input_types') */
     cpy_r_r14 = PyObject_VectorcallMethod(cpy_r_r10, cpy_r_r12, 9223372036854775809ULL, cpy_r_r13);
     if (unlikely(cpy_r_r14 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/abi.py", "abi_to_signature", 204, CPyStatic_abi___globals);
@@ -2033,7 +2033,7 @@ CPyL15: ;
     cpy_r_r29 = CPyStatics[38]; /* 'format' */
     PyObject *cpy_r_r30[3] = {cpy_r_r0, cpy_r_fn_name, cpy_r_r28};
     cpy_r_r31 = (PyObject **)&cpy_r_r30;
-    cpy_r_r32 = CPyStatics[334]; /* ('name', 'input_types') */
+    cpy_r_r32 = CPyStatics[335]; /* ('name', 'input_types') */
     cpy_r_r33 = PyObject_VectorcallMethod(cpy_r_r29, cpy_r_r31, 9223372036854775809ULL, cpy_r_r32);
     if (unlikely(cpy_r_r33 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/abi.py", "abi_to_signature", 211, CPyStatic_abi___globals);
@@ -4363,7 +4363,7 @@ CPyL78: ;
     }
     PyObject *cpy_r_r152[2] = {cpy_r_r146, cpy_r_r147};
     cpy_r_r153 = (PyObject **)&cpy_r_r152;
-    cpy_r_r154 = CPyStatics[335]; /* ('key',) */
+    cpy_r_r154 = CPyStatics[336]; /* ('key',) */
     cpy_r_r155 = PyObject_Vectorcall(cpy_r_r151, cpy_r_r153, 1, cpy_r_r154);
     CPy_DECREF(cpy_r_r151);
     if (unlikely(cpy_r_r155 == NULL)) {
@@ -5618,7 +5618,7 @@ PyObject *CPyDef_abi___function_signature_to_4byte_selector(PyObject *cpy_r_func
     }
     PyObject *cpy_r_r6[1] = {cpy_r_r2};
     cpy_r_r7 = (PyObject **)&cpy_r_r6;
-    cpy_r_r8 = CPyStatics[336]; /* ('text',) */
+    cpy_r_r8 = CPyStatics[337]; /* ('text',) */
     cpy_r_r9 = PyObject_Vectorcall(cpy_r_r5, cpy_r_r7, 0, cpy_r_r8);
     CPy_DECREF(cpy_r_r5);
     if (unlikely(cpy_r_r9 == NULL)) {
@@ -5738,7 +5738,7 @@ PyObject *CPyDef_abi___event_signature_to_log_topic(PyObject *cpy_r_event_signat
     }
     PyObject *cpy_r_r6[1] = {cpy_r_r2};
     cpy_r_r7 = (PyObject **)&cpy_r_r6;
-    cpy_r_r8 = CPyStatics[336]; /* ('text',) */
+    cpy_r_r8 = CPyStatics[337]; /* ('text',) */
     cpy_r_r9 = PyObject_Vectorcall(cpy_r_r5, cpy_r_r7, 0, cpy_r_r8);
     CPy_DECREF(cpy_r_r5);
     if (unlikely(cpy_r_r9 == NULL)) {
@@ -5875,7 +5875,7 @@ char CPyDef_abi_____top_level__(void) {
     CPy_INCREF(CPyModule_builtins);
     CPy_DECREF(cpy_r_r4);
 CPyL3: ;
-    cpy_r_r5 = CPyStatics[337]; /* ('abc',) */
+    cpy_r_r5 = CPyStatics[338]; /* ('abc',) */
     cpy_r_r6 = CPyStatics[66]; /* 'collections' */
     cpy_r_r7 = CPyStatic_abi___globals;
     cpy_r_r8 = CPyImport_ImportFromMany(cpy_r_r6, cpy_r_r5, cpy_r_r5, cpy_r_r7);
@@ -5893,7 +5893,7 @@ CPyL3: ;
     cpy_r_r13 = (void *)&cpy_r_r12;
     int64_t cpy_r_r14[3] = {4, 5, 6};
     cpy_r_r15 = (void *)&cpy_r_r14;
-    cpy_r_r16 = CPyStatics[341]; /* (('copy', 'copy', 'copy'),
+    cpy_r_r16 = CPyStatics[342]; /* (('copy', 'copy', 'copy'),
                                     ('itertools', 'itertools', 'itertools'),
                                     ('re', 're', 're')) */
     cpy_r_r17 = CPyStatic_abi___globals;
@@ -5901,7 +5901,7 @@ CPyL3: ;
     cpy_r_r19 = CPyStatics[70]; /* '<module>' */
     cpy_r_r20 = CPyImport_ImportMany(cpy_r_r16, cpy_r_r13, cpy_r_r17, cpy_r_r18, cpy_r_r19, cpy_r_r15);
     if (!cpy_r_r20) goto CPyL10;
-    cpy_r_r21 = CPyStatics[342]; /* ('Any', 'Dict', 'Iterable', 'List', 'Literal', 'Mapping',
+    cpy_r_r21 = CPyStatics[343]; /* ('Any', 'Dict', 'Iterable', 'List', 'Literal', 'Mapping',
                                     'Optional', 'Sequence', 'Tuple', 'Union', 'cast',
                                     'overload') */
     cpy_r_r22 = CPyStatics[81]; /* 'typing' */
@@ -5914,7 +5914,7 @@ CPyL3: ;
     CPyModule_typing = cpy_r_r24;
     CPy_INCREF(CPyModule_typing);
     CPy_DECREF(cpy_r_r24);
-    cpy_r_r25 = CPyStatics[343]; /* ('ABI', 'ABIComponent', 'ABIConstructor', 'ABIElement',
+    cpy_r_r25 = CPyStatics[344]; /* ('ABI', 'ABIComponent', 'ABIConstructor', 'ABIElement',
                                     'ABIError', 'ABIEvent', 'ABIFallback', 'ABIFunction',
                                     'ABIReceive') */
     cpy_r_r26 = CPyStatics[91]; /* 'eth_typing' */
@@ -5927,7 +5927,7 @@ CPyL3: ;
     CPyModule_eth_typing = cpy_r_r28;
     CPy_INCREF(CPyModule_eth_typing);
     CPy_DECREF(cpy_r_r28);
-    cpy_r_r29 = CPyStatics[344]; /* ('is_list_like',) */
+    cpy_r_r29 = CPyStatics[345]; /* ('is_list_like',) */
     cpy_r_r30 = CPyStatics[93]; /* 'faster_eth_utils.types' */
     cpy_r_r31 = CPyStatic_abi___globals;
     cpy_r_r32 = CPyImport_ImportFromMany(cpy_r_r30, cpy_r_r29, cpy_r_r29, cpy_r_r31);
@@ -5938,7 +5938,7 @@ CPyL3: ;
     CPyModule_faster_eth_utils___types = cpy_r_r32;
     CPy_INCREF(CPyModule_faster_eth_utils___types);
     CPy_DECREF(cpy_r_r32);
-    cpy_r_r33 = CPyStatics[345]; /* ('keccak',) */
+    cpy_r_r33 = CPyStatics[346]; /* ('keccak',) */
     cpy_r_r34 = CPyStatics[94]; /* 'faster_eth_utils.crypto' */
     cpy_r_r35 = CPyStatic_abi___globals;
     cpy_r_r36 = CPyImport_ImportFromMany(cpy_r_r34, cpy_r_r33, cpy_r_r33, cpy_r_r35);
@@ -6021,7 +6021,7 @@ char CPyDef_address___is_hex_address(PyObject *cpy_r_value) {
     char cpy_r_r10;
     cpy_r_r0 = CPyDef_types___is_text(cpy_r_value);
     if (unlikely(cpy_r_r0 == 2)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "is_hex_address", 43, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "is_hex_address", 44, CPyStatic_address___globals);
         goto CPyL9;
     }
     if (cpy_r_r0) goto CPyL3;
@@ -6032,7 +6032,7 @@ CPyL3: ;
     PyErr_SetString(PyExc_NameError, "value for final name \"_HEX_ADDRESS_REGEXP\" was not set");
     cpy_r_r2 = 0;
     if (unlikely(!cpy_r_r2)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "is_hex_address", 45, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "is_hex_address", 46, CPyStatic_address___globals);
         goto CPyL9;
     }
     CPy_Unreachable();
@@ -6041,7 +6041,7 @@ CPyL6: ;
     if (likely(PyUnicode_Check(cpy_r_value)))
         cpy_r_r3 = cpy_r_value;
     else {
-        CPy_TypeErrorTraceback("faster_eth_utils/address.py", "is_hex_address", 45, CPyStatic_address___globals, "str", cpy_r_value);
+        CPy_TypeErrorTraceback("faster_eth_utils/address.py", "is_hex_address", 46, CPyStatic_address___globals, "str", cpy_r_value);
         goto CPyL9;
     }
     cpy_r_r4 = CPyStatics[95]; /* 'fullmatch' */
@@ -6049,7 +6049,7 @@ CPyL6: ;
     cpy_r_r6 = (PyObject **)&cpy_r_r5;
     cpy_r_r7 = PyObject_VectorcallMethod(cpy_r_r4, cpy_r_r6, 9223372036854775810ULL, 0);
     if (unlikely(cpy_r_r7 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "is_hex_address", 45, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "is_hex_address", 46, CPyStatic_address___globals);
         goto CPyL10;
     }
     CPy_DECREF(cpy_r_r3);
@@ -6081,7 +6081,7 @@ PyObject *CPyPy_address___is_hex_address(PyObject *self, PyObject *const *args, 
     CPy_INCREF(retbox);
     return retbox;
 fail: ;
-    CPy_AddTraceback("faster_eth_utils/address.py", "is_hex_address", 39, CPyStatic_address___globals);
+    CPy_AddTraceback("faster_eth_utils/address.py", "is_hex_address", 40, CPyStatic_address___globals);
     return NULL;
 }
 
@@ -6092,7 +6092,7 @@ char CPyDef_address___is_binary_address(PyObject *cpy_r_value) {
     char cpy_r_r3;
     cpy_r_r0 = CPyDef_types___is_bytes(cpy_r_value);
     if (unlikely(cpy_r_r0 == 2)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "is_binary_address", 52, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "is_binary_address", 53, CPyStatic_address___globals);
         goto CPyL7;
     }
     if (cpy_r_r0) goto CPyL3;
@@ -6100,7 +6100,7 @@ char CPyDef_address___is_binary_address(PyObject *cpy_r_value) {
 CPyL3: ;
     cpy_r_r1 = CPyObject_Size(cpy_r_value);
     if (unlikely(cpy_r_r1 == CPY_INT_TAG)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "is_binary_address", 54, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "is_binary_address", 55, CPyStatic_address___globals);
         goto CPyL7;
     }
     cpy_r_r2 = cpy_r_r1 != 40;
@@ -6130,7 +6130,7 @@ PyObject *CPyPy_address___is_binary_address(PyObject *self, PyObject *const *arg
     CPy_INCREF(retbox);
     return retbox;
 fail: ;
-    CPy_AddTraceback("faster_eth_utils/address.py", "is_binary_address", 48, CPyStatic_address___globals);
+    CPy_AddTraceback("faster_eth_utils/address.py", "is_binary_address", 49, CPyStatic_address___globals);
     return NULL;
 }
 
@@ -6140,13 +6140,13 @@ char CPyDef_address___is_address(PyObject *cpy_r_value) {
     char cpy_r_r2;
     cpy_r_r0 = CPyDef_address___is_hex_address(cpy_r_value);
     if (unlikely(cpy_r_r0 == 2)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "is_address", 64, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "is_address", 65, CPyStatic_address___globals);
         goto CPyL6;
     }
     if (cpy_r_r0) goto CPyL4;
     cpy_r_r1 = CPyDef_address___is_binary_address(cpy_r_value);
     if (unlikely(cpy_r_r1 == 2)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "is_address", 64, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "is_address", 65, CPyStatic_address___globals);
         goto CPyL6;
     }
     if (!cpy_r_r1) goto CPyL5;
@@ -6175,7 +6175,7 @@ PyObject *CPyPy_address___is_address(PyObject *self, PyObject *const *args, size
     CPy_INCREF(retbox);
     return retbox;
 fail: ;
-    CPy_AddTraceback("faster_eth_utils/address.py", "is_address", 60, CPyStatic_address___globals);
+    CPy_AddTraceback("faster_eth_utils/address.py", "is_address", 61, CPyStatic_address___globals);
     return NULL;
 }
 
@@ -6220,7 +6220,7 @@ PyObject *CPyDef_address___to_normalized_address(PyObject *cpy_r_value) {
     cpy_r_r1 = CPyStatics[96]; /* 'to_hex' */
     cpy_r_r2 = CPyDict_GetItem(cpy_r_r0, cpy_r_r1);
     if (unlikely(cpy_r_r2 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "to_normalized_address", 75, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "to_normalized_address", 76, CPyStatic_address___globals);
         goto CPyL7;
     }
     CPy_INCREF(cpy_r_value);
@@ -6242,14 +6242,14 @@ PyObject *CPyDef_address___to_normalized_address(PyObject *cpy_r_value) {
         cpy_r_r3 = NULL;
     }
     if (cpy_r_r3 != NULL) goto __LL32;
-    CPy_TypeErrorTraceback("faster_eth_utils/address.py", "to_normalized_address", 75, CPyStatic_address___globals, "union[bytes, int, str]", cpy_r_value);
+    CPy_TypeErrorTraceback("faster_eth_utils/address.py", "to_normalized_address", 76, CPyStatic_address___globals, "union[bytes, int, str]", cpy_r_value);
     goto CPyL30;
 __LL32: ;
     cpy_r_r4 = CPyDef_conversions___hexstr_if_str(cpy_r_r2, cpy_r_r3);
     CPy_DECREF(cpy_r_r2);
     CPy_DECREF(cpy_r_r3);
     if (unlikely(cpy_r_r4 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "to_normalized_address", 75, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "to_normalized_address", 76, CPyStatic_address___globals);
         goto CPyL7;
     }
     cpy_r_r5 = CPyStatics[97]; /* 'lower' */
@@ -6257,14 +6257,14 @@ __LL32: ;
     cpy_r_r7 = (PyObject **)&cpy_r_r6;
     cpy_r_r8 = PyObject_VectorcallMethod(cpy_r_r5, cpy_r_r7, 9223372036854775809ULL, 0);
     if (unlikely(cpy_r_r8 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "to_normalized_address", 75, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "to_normalized_address", 76, CPyStatic_address___globals);
         goto CPyL31;
     }
     CPy_DECREF(cpy_r_r4);
     if (likely(PyUnicode_Check(cpy_r_r8)))
         cpy_r_r9 = cpy_r_r8;
     else {
-        CPy_TypeErrorTraceback("faster_eth_utils/address.py", "to_normalized_address", 75, CPyStatic_address___globals, "str", cpy_r_r8);
+        CPy_TypeErrorTraceback("faster_eth_utils/address.py", "to_normalized_address", 76, CPyStatic_address___globals, "str", cpy_r_r8);
         goto CPyL7;
     }
     goto CPyL19;
@@ -6274,7 +6274,7 @@ CPyL7: ;
     cpy_r_r12 = CPyStatics[98]; /* 'AttributeError' */
     cpy_r_r13 = CPyObject_GetAttr(cpy_r_r11, cpy_r_r12);
     if (unlikely(cpy_r_r13 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "to_normalized_address", 76, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "to_normalized_address", 77, CPyStatic_address___globals);
         goto CPyL17;
     }
     cpy_r_r14 = CPy_ExceptionMatches(cpy_r_r13);
@@ -6285,20 +6285,20 @@ CPyL7: ;
     cpy_r_r17 = PyObject_Str(cpy_r_r16);
     CPy_DecRef(cpy_r_r16);
     if (unlikely(cpy_r_r17 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "to_normalized_address", 77, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "to_normalized_address", 78, CPyStatic_address___globals);
         goto CPyL17;
     }
     cpy_r_r18 = CPyStr_Build(2, cpy_r_r15, cpy_r_r17);
     CPy_DecRef(cpy_r_r17);
     if (unlikely(cpy_r_r18 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "to_normalized_address", 77, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "to_normalized_address", 78, CPyStatic_address___globals);
         goto CPyL17;
     }
     cpy_r_r19 = CPyModule_builtins;
     cpy_r_r20 = CPyStatics[16]; /* 'TypeError' */
     cpy_r_r21 = CPyObject_GetAttr(cpy_r_r19, cpy_r_r20);
     if (unlikely(cpy_r_r21 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "to_normalized_address", 77, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "to_normalized_address", 78, CPyStatic_address___globals);
         goto CPyL32;
     }
     PyObject *cpy_r_r22[1] = {cpy_r_r18};
@@ -6306,14 +6306,14 @@ CPyL7: ;
     cpy_r_r24 = PyObject_Vectorcall(cpy_r_r21, cpy_r_r23, 1, 0);
     CPy_DecRef(cpy_r_r21);
     if (unlikely(cpy_r_r24 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "to_normalized_address", 77, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "to_normalized_address", 78, CPyStatic_address___globals);
         goto CPyL32;
     }
     CPy_DecRef(cpy_r_r18);
     CPy_Raise(cpy_r_r24);
     CPy_DecRef(cpy_r_r24);
     if (unlikely(!0)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "to_normalized_address", 77, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "to_normalized_address", 78, CPyStatic_address___globals);
         goto CPyL17;
     } else
         goto CPyL33;
@@ -6338,7 +6338,7 @@ CPyL17: ;
 CPyL19: ;
     cpy_r_r26 = CPyDef_address___is_address(cpy_r_r9);
     if (unlikely(cpy_r_r26 == 2)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "to_normalized_address", 78, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "to_normalized_address", 79, CPyStatic_address___globals);
         goto CPyL35;
     }
     if (!cpy_r_r26) goto CPyL22;
@@ -6347,28 +6347,28 @@ CPyL22: ;
     cpy_r_r27 = CPyStatics[100]; /* 'Unknown format ' */
     cpy_r_r28 = PyObject_Repr(cpy_r_value);
     if (unlikely(cpy_r_r28 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "to_normalized_address", 82, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "to_normalized_address", 83, CPyStatic_address___globals);
         goto CPyL35;
     }
     cpy_r_r29 = CPyStatics[101]; /* ', attempted to normalize to ' */
     cpy_r_r30 = PyObject_Repr(cpy_r_r9);
     CPy_DECREF(cpy_r_r9);
     if (unlikely(cpy_r_r30 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "to_normalized_address", 83, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "to_normalized_address", 84, CPyStatic_address___globals);
         goto CPyL36;
     }
     cpy_r_r31 = CPyStr_Build(4, cpy_r_r27, cpy_r_r28, cpy_r_r29, cpy_r_r30);
     CPy_DECREF(cpy_r_r28);
     CPy_DECREF(cpy_r_r30);
     if (unlikely(cpy_r_r31 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "to_normalized_address", 82, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "to_normalized_address", 83, CPyStatic_address___globals);
         goto CPyL29;
     }
     cpy_r_r32 = CPyModule_builtins;
     cpy_r_r33 = CPyStatics[25]; /* 'ValueError' */
     cpy_r_r34 = CPyObject_GetAttr(cpy_r_r32, cpy_r_r33);
     if (unlikely(cpy_r_r34 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "to_normalized_address", 81, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "to_normalized_address", 82, CPyStatic_address___globals);
         goto CPyL37;
     }
     PyObject *cpy_r_r35[1] = {cpy_r_r31};
@@ -6376,14 +6376,14 @@ CPyL22: ;
     cpy_r_r37 = PyObject_Vectorcall(cpy_r_r34, cpy_r_r36, 1, 0);
     CPy_DECREF(cpy_r_r34);
     if (unlikely(cpy_r_r37 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "to_normalized_address", 81, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "to_normalized_address", 82, CPyStatic_address___globals);
         goto CPyL37;
     }
     CPy_DECREF(cpy_r_r31);
     CPy_Raise(cpy_r_r37);
     CPy_DECREF(cpy_r_r37);
     if (unlikely(!0)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "to_normalized_address", 81, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "to_normalized_address", 82, CPyStatic_address___globals);
         goto CPyL29;
     }
     CPy_Unreachable();
@@ -6448,7 +6448,7 @@ __LL33: ;
     PyObject *retval = CPyDef_address___to_normalized_address(arg_value);
     return retval;
 fail: ;
-    CPy_AddTraceback("faster_eth_utils/address.py", "to_normalized_address", 70, CPyStatic_address___globals);
+    CPy_AddTraceback("faster_eth_utils/address.py", "to_normalized_address", 71, CPyStatic_address___globals);
     return NULL;
 }
 
@@ -6462,7 +6462,7 @@ char CPyDef_address___is_normalized_address(PyObject *cpy_r_value) {
     char cpy_r_r6;
     cpy_r_r0 = CPyDef_address___is_address(cpy_r_value);
     if (unlikely(cpy_r_r0 == 2)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "is_normalized_address", 91, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "is_normalized_address", 92, CPyStatic_address___globals);
         goto CPyL8;
     }
     if (cpy_r_r0) goto CPyL3;
@@ -6472,13 +6472,13 @@ char CPyDef_address___is_normalized_address(PyObject *cpy_r_value) {
 CPyL3: ;
     cpy_r_r3 = CPyDef_address___to_normalized_address(cpy_r_value);
     if (unlikely(cpy_r_r3 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "is_normalized_address", 91, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "is_normalized_address", 92, CPyStatic_address___globals);
         goto CPyL8;
     }
     cpy_r_r4 = PyObject_RichCompare(cpy_r_value, cpy_r_r3, 2);
     CPy_DECREF(cpy_r_r3);
     if (unlikely(cpy_r_r4 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "is_normalized_address", 91, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "is_normalized_address", 92, CPyStatic_address___globals);
         goto CPyL8;
     }
     cpy_r_r2 = cpy_r_r4;
@@ -6489,7 +6489,7 @@ CPyL6: ;
         cpy_r_r5 = cpy_r_r2 == Py_True;
     CPy_DECREF(cpy_r_r2);
     if (unlikely(cpy_r_r5 == 2)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "is_normalized_address", 91, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "is_normalized_address", 92, CPyStatic_address___globals);
         goto CPyL8;
     }
     return cpy_r_r5;
@@ -6514,7 +6514,7 @@ PyObject *CPyPy_address___is_normalized_address(PyObject *self, PyObject *const 
     CPy_INCREF(retbox);
     return retbox;
 fail: ;
-    CPy_AddTraceback("faster_eth_utils/address.py", "is_normalized_address", 87, CPyStatic_address___globals);
+    CPy_AddTraceback("faster_eth_utils/address.py", "is_normalized_address", 88, CPyStatic_address___globals);
     return NULL;
 }
 
@@ -6525,19 +6525,19 @@ PyObject *CPyDef_address___to_canonical_address(PyObject *cpy_r_address) {
     PyObject *cpy_r_r3;
     cpy_r_r0 = CPyDef_address___to_normalized_address(cpy_r_address);
     if (unlikely(cpy_r_r0 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "to_canonical_address", 98, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "to_canonical_address", 99, CPyStatic_address___globals);
         goto CPyL4;
     }
     if (likely(PyUnicode_Check(cpy_r_r0)))
         cpy_r_r1 = cpy_r_r0;
     else {
-        CPy_TypeErrorTraceback("faster_eth_utils/address.py", "to_canonical_address", 98, CPyStatic_address___globals, "str", cpy_r_r0);
+        CPy_TypeErrorTraceback("faster_eth_utils/address.py", "to_canonical_address", 99, CPyStatic_address___globals, "str", cpy_r_r0);
         goto CPyL4;
     }
     cpy_r_r2 = CPyDef_hexadecimal___decode_hex(cpy_r_r1);
     CPy_DECREF(cpy_r_r1);
     if (unlikely(cpy_r_r2 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "to_canonical_address", 98, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "to_canonical_address", 99, CPyStatic_address___globals);
         goto CPyL4;
     }
     return cpy_r_r2;
@@ -6574,7 +6574,7 @@ __LL34: ;
     PyObject *retval = CPyDef_address___to_canonical_address(arg_address);
     return retval;
 fail: ;
-    CPy_AddTraceback("faster_eth_utils/address.py", "to_canonical_address", 94, CPyStatic_address___globals);
+    CPy_AddTraceback("faster_eth_utils/address.py", "to_canonical_address", 95, CPyStatic_address___globals);
     return NULL;
 }
 
@@ -6589,7 +6589,7 @@ char CPyDef_address___is_canonical_address(PyObject *cpy_r_address) {
     char cpy_r_r7;
     cpy_r_r0 = CPyDef_address___is_binary_address(cpy_r_address);
     if (unlikely(cpy_r_r0 == 2)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "is_canonical_address", 105, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "is_canonical_address", 106, CPyStatic_address___globals);
         goto CPyL10;
     }
     if (cpy_r_r0) goto CPyL3;
@@ -6600,27 +6600,27 @@ CPyL3: ;
     if (likely(PyBytes_Check(cpy_r_address) || PyByteArray_Check(cpy_r_address)))
         cpy_r_r2 = cpy_r_address;
     else {
-        CPy_TypeErrorTraceback("faster_eth_utils/address.py", "is_canonical_address", 105, CPyStatic_address___globals, "bytes", cpy_r_address);
+        CPy_TypeErrorTraceback("faster_eth_utils/address.py", "is_canonical_address", 106, CPyStatic_address___globals, "bytes", cpy_r_address);
         goto CPyL10;
     }
     CPy_INCREF(cpy_r_address);
     if (likely(PyBytes_Check(cpy_r_address) || PyByteArray_Check(cpy_r_address)))
         cpy_r_r3 = cpy_r_address;
     else {
-        CPy_TypeErrorTraceback("faster_eth_utils/address.py", "is_canonical_address", 105, CPyStatic_address___globals, "bytes", cpy_r_address);
+        CPy_TypeErrorTraceback("faster_eth_utils/address.py", "is_canonical_address", 106, CPyStatic_address___globals, "bytes", cpy_r_address);
         goto CPyL11;
     }
     cpy_r_r4 = CPyDef_address___to_canonical_address(cpy_r_r3);
     CPy_DECREF(cpy_r_r3);
     if (unlikely(cpy_r_r4 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "is_canonical_address", 105, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "is_canonical_address", 106, CPyStatic_address___globals);
         goto CPyL11;
     }
     cpy_r_r5 = PyObject_RichCompare(cpy_r_r2, cpy_r_r4, 2);
     CPy_DECREF(cpy_r_r2);
     CPy_DECREF(cpy_r_r4);
     if (unlikely(cpy_r_r5 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "is_canonical_address", 105, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "is_canonical_address", 106, CPyStatic_address___globals);
         goto CPyL10;
     }
     if (unlikely(!PyBool_Check(cpy_r_r5))) {
@@ -6629,7 +6629,7 @@ CPyL3: ;
         cpy_r_r6 = cpy_r_r5 == Py_True;
     CPy_DECREF(cpy_r_r5);
     if (unlikely(cpy_r_r6 == 2)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "is_canonical_address", 105, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "is_canonical_address", 106, CPyStatic_address___globals);
         goto CPyL10;
     }
     cpy_r_r1 = cpy_r_r6;
@@ -6659,7 +6659,7 @@ PyObject *CPyPy_address___is_canonical_address(PyObject *self, PyObject *const *
     CPy_INCREF(retbox);
     return retbox;
 fail: ;
-    CPy_AddTraceback("faster_eth_utils/address.py", "is_canonical_address", 101, CPyStatic_address___globals);
+    CPy_AddTraceback("faster_eth_utils/address.py", "is_canonical_address", 102, CPyStatic_address___globals);
     return NULL;
 }
 
@@ -6679,13 +6679,13 @@ char CPyDef_address___is_same_address(PyObject *cpy_r_left, PyObject *cpy_r_righ
     char cpy_r_r13;
     cpy_r_r0 = CPyDef_address___is_address(cpy_r_left);
     if (unlikely(cpy_r_r0 == 2)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "is_same_address", 114, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "is_same_address", 115, CPyStatic_address___globals);
         goto CPyL13;
     }
     if (!cpy_r_r0) goto CPyL4;
     cpy_r_r1 = CPyDef_address___is_address(cpy_r_right);
     if (unlikely(cpy_r_r1 == 2)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "is_same_address", 114, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "is_same_address", 115, CPyStatic_address___globals);
         goto CPyL13;
     }
     if (cpy_r_r1) goto CPyL8;
@@ -6695,7 +6695,7 @@ CPyL4: ;
     cpy_r_r4 = CPyStatics[25]; /* 'ValueError' */
     cpy_r_r5 = CPyObject_GetAttr(cpy_r_r3, cpy_r_r4);
     if (unlikely(cpy_r_r5 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "is_same_address", 115, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "is_same_address", 116, CPyStatic_address___globals);
         goto CPyL13;
     }
     PyObject *cpy_r_r6[1] = {cpy_r_r2};
@@ -6703,32 +6703,32 @@ CPyL4: ;
     cpy_r_r8 = PyObject_Vectorcall(cpy_r_r5, cpy_r_r7, 1, 0);
     CPy_DECREF(cpy_r_r5);
     if (unlikely(cpy_r_r8 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "is_same_address", 115, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "is_same_address", 116, CPyStatic_address___globals);
         goto CPyL13;
     }
     CPy_Raise(cpy_r_r8);
     CPy_DECREF(cpy_r_r8);
     if (unlikely(!0)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "is_same_address", 115, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "is_same_address", 116, CPyStatic_address___globals);
         goto CPyL13;
     }
     CPy_Unreachable();
 CPyL8: ;
     cpy_r_r9 = CPyDef_address___to_normalized_address(cpy_r_left);
     if (unlikely(cpy_r_r9 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "is_same_address", 117, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "is_same_address", 118, CPyStatic_address___globals);
         goto CPyL13;
     }
     cpy_r_r10 = CPyDef_address___to_normalized_address(cpy_r_right);
     if (unlikely(cpy_r_r10 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "is_same_address", 117, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "is_same_address", 118, CPyStatic_address___globals);
         goto CPyL14;
     }
     cpy_r_r11 = PyObject_RichCompare(cpy_r_r9, cpy_r_r10, 2);
     CPy_DECREF(cpy_r_r9);
     CPy_DECREF(cpy_r_r10);
     if (unlikely(cpy_r_r11 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "is_same_address", 117, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "is_same_address", 118, CPyStatic_address___globals);
         goto CPyL13;
     }
     if (unlikely(!PyBool_Check(cpy_r_r11))) {
@@ -6737,7 +6737,7 @@ CPyL8: ;
         cpy_r_r12 = cpy_r_r11 == Py_True;
     CPy_DECREF(cpy_r_r11);
     if (unlikely(cpy_r_r12 == 2)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "is_same_address", 117, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "is_same_address", 118, CPyStatic_address___globals);
         goto CPyL13;
     }
     return cpy_r_r12;
@@ -6801,7 +6801,7 @@ __LL36: ;
     CPy_INCREF(retbox);
     return retbox;
 fail: ;
-    CPy_AddTraceback("faster_eth_utils/address.py", "is_same_address", 108, CPyStatic_address___globals);
+    CPy_AddTraceback("faster_eth_utils/address.py", "is_same_address", 109, CPyStatic_address___globals);
     return NULL;
 }
 
@@ -6852,47 +6852,47 @@ PyObject *CPyDef_address___to_checksum_address(PyObject *cpy_r_value) {
     PyObject *cpy_r_r44;
     cpy_r_r0 = CPyDef_address___to_normalized_address(cpy_r_value);
     if (unlikely(cpy_r_r0 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "to_checksum_address", 124, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "to_checksum_address", 125, CPyStatic_address___globals);
         goto CPyL31;
     }
     cpy_r_r1 = CPyDef_hexadecimal___remove_0x_prefix(cpy_r_r0);
     if (unlikely(cpy_r_r1 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "to_checksum_address", 125, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "to_checksum_address", 126, CPyStatic_address___globals);
         goto CPyL32;
     }
     cpy_r_r2 = CPyStatic_address___globals;
     cpy_r_r3 = CPyStatics[63]; /* 'keccak' */
     cpy_r_r4 = CPyDict_GetItem(cpy_r_r2, cpy_r_r3);
     if (unlikely(cpy_r_r4 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "to_checksum_address", 125, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "to_checksum_address", 126, CPyStatic_address___globals);
         goto CPyL33;
     }
     PyObject *cpy_r_r5[1] = {cpy_r_r1};
     cpy_r_r6 = (PyObject **)&cpy_r_r5;
-    cpy_r_r7 = CPyStatics[336]; /* ('text',) */
+    cpy_r_r7 = CPyStatics[337]; /* ('text',) */
     cpy_r_r8 = PyObject_Vectorcall(cpy_r_r4, cpy_r_r6, 0, cpy_r_r7);
     CPy_DECREF(cpy_r_r4);
     if (unlikely(cpy_r_r8 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "to_checksum_address", 125, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "to_checksum_address", 126, CPyStatic_address___globals);
         goto CPyL33;
     }
     CPy_DECREF(cpy_r_r1);
     if (likely(PyBytes_Check(cpy_r_r8) || PyByteArray_Check(cpy_r_r8)))
         cpy_r_r9 = cpy_r_r8;
     else {
-        CPy_TypeErrorTraceback("faster_eth_utils/address.py", "to_checksum_address", 125, CPyStatic_address___globals, "bytes", cpy_r_r8);
+        CPy_TypeErrorTraceback("faster_eth_utils/address.py", "to_checksum_address", 126, CPyStatic_address___globals, "bytes", cpy_r_r8);
         goto CPyL32;
     }
     cpy_r_r10 = CPyDef_hexadecimal___encode_hex(cpy_r_r9);
     CPy_DECREF(cpy_r_r9);
     if (unlikely(cpy_r_r10 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "to_checksum_address", 125, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "to_checksum_address", 126, CPyStatic_address___globals);
         goto CPyL32;
     }
     cpy_r_r11 = CPyStatics[4]; /* '' */
     cpy_r_r12 = PyList_New(0);
     if (unlikely(cpy_r_r12 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "to_checksum_address", 129, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "to_checksum_address", 130, CPyStatic_address___globals);
         goto CPyL34;
     }
     cpy_r_r13 = 4;
@@ -6905,19 +6905,19 @@ CPyL8: ;
     cpy_r_r16 = PyObject_GetItem(cpy_r_r10, cpy_r_r15);
     CPy_DECREF(cpy_r_r15);
     if (unlikely(cpy_r_r16 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "to_checksum_address", 132, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "to_checksum_address", 133, CPyStatic_address___globals);
         goto CPyL36;
     }
     if (likely(PyUnicode_Check(cpy_r_r16)))
         cpy_r_r17 = cpy_r_r16;
     else {
-        CPy_TypeErrorTraceback("faster_eth_utils/address.py", "to_checksum_address", 132, CPyStatic_address___globals, "str", cpy_r_r16);
+        CPy_TypeErrorTraceback("faster_eth_utils/address.py", "to_checksum_address", 133, CPyStatic_address___globals, "str", cpy_r_r16);
         goto CPyL36;
     }
     cpy_r_r18 = CPyLong_FromStrWithBase(cpy_r_r17, 32);
     CPy_DECREF(cpy_r_r17);
     if (unlikely(cpy_r_r18 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "to_checksum_address", 132, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "to_checksum_address", 133, CPyStatic_address___globals);
         goto CPyL36;
     }
     if (likely(PyLong_Check(cpy_r_r18)))
@@ -6927,7 +6927,7 @@ CPyL8: ;
     }
     CPy_DECREF(cpy_r_r18);
     if (unlikely(cpy_r_r19 == CPY_INT_TAG)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "to_checksum_address", 132, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "to_checksum_address", 133, CPyStatic_address___globals);
         goto CPyL36;
     }
     cpy_r_r20 = cpy_r_r19 & 1;
@@ -6950,13 +6950,13 @@ CPyL17: ;
     cpy_r_r28 = PyObject_GetItem(cpy_r_r0, cpy_r_r27);
     CPy_DECREF(cpy_r_r27);
     if (unlikely(cpy_r_r28 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "to_checksum_address", 131, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "to_checksum_address", 132, CPyStatic_address___globals);
         goto CPyL37;
     }
     if (likely(PyUnicode_Check(cpy_r_r28)))
         cpy_r_r29 = cpy_r_r28;
     else {
-        CPy_TypeErrorTraceback("faster_eth_utils/address.py", "to_checksum_address", 131, CPyStatic_address___globals, "str", cpy_r_r28);
+        CPy_TypeErrorTraceback("faster_eth_utils/address.py", "to_checksum_address", 132, CPyStatic_address___globals, "str", cpy_r_r28);
         goto CPyL37;
     }
     cpy_r_r30 = CPyStatics[103]; /* 'upper' */
@@ -6964,14 +6964,14 @@ CPyL17: ;
     cpy_r_r32 = (PyObject **)&cpy_r_r31;
     cpy_r_r33 = PyObject_VectorcallMethod(cpy_r_r30, cpy_r_r32, 9223372036854775809ULL, 0);
     if (unlikely(cpy_r_r33 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "to_checksum_address", 131, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "to_checksum_address", 132, CPyStatic_address___globals);
         goto CPyL38;
     }
     CPy_DECREF(cpy_r_r29);
     if (likely(PyUnicode_Check(cpy_r_r33)))
         cpy_r_r34 = cpy_r_r33;
     else {
-        CPy_TypeErrorTraceback("faster_eth_utils/address.py", "to_checksum_address", 131, CPyStatic_address___globals, "str", cpy_r_r33);
+        CPy_TypeErrorTraceback("faster_eth_utils/address.py", "to_checksum_address", 132, CPyStatic_address___globals, "str", cpy_r_r33);
         goto CPyL37;
     }
     cpy_r_r35 = cpy_r_r34;
@@ -6981,13 +6981,13 @@ CPyL23: ;
     cpy_r_r37 = PyObject_GetItem(cpy_r_r0, cpy_r_r36);
     CPy_DECREF(cpy_r_r36);
     if (unlikely(cpy_r_r37 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "to_checksum_address", 133, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "to_checksum_address", 134, CPyStatic_address___globals);
         goto CPyL37;
     }
     if (likely(PyUnicode_Check(cpy_r_r37)))
         cpy_r_r38 = cpy_r_r37;
     else {
-        CPy_TypeErrorTraceback("faster_eth_utils/address.py", "to_checksum_address", 133, CPyStatic_address___globals, "str", cpy_r_r37);
+        CPy_TypeErrorTraceback("faster_eth_utils/address.py", "to_checksum_address", 134, CPyStatic_address___globals, "str", cpy_r_r37);
         goto CPyL37;
     }
     cpy_r_r35 = cpy_r_r38;
@@ -6996,7 +6996,7 @@ CPyL26: ;
     CPy_DECREF(cpy_r_r35);
     cpy_r_r40 = cpy_r_r39 >= 0;
     if (unlikely(!cpy_r_r40)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "to_checksum_address", 129, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "to_checksum_address", 130, CPyStatic_address___globals);
         goto CPyL37;
     }
     cpy_r_r41 = cpy_r_r13 + 2;
@@ -7007,13 +7007,13 @@ CPyL28: ;
     cpy_r_r42 = PyUnicode_Join(cpy_r_r11, cpy_r_r12);
     CPy_DECREF_NO_IMM(cpy_r_r12);
     if (unlikely(cpy_r_r42 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "to_checksum_address", 129, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "to_checksum_address", 130, CPyStatic_address___globals);
         goto CPyL31;
     }
     cpy_r_r43 = CPyDef_hexadecimal___add_0x_prefix(cpy_r_r42);
     CPy_DECREF(cpy_r_r42);
     if (unlikely(cpy_r_r43 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "to_checksum_address", 127, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "to_checksum_address", 128, CPyStatic_address___globals);
         goto CPyL31;
     }
     return cpy_r_r43;
@@ -7083,7 +7083,7 @@ __LL37: ;
     PyObject *retval = CPyDef_address___to_checksum_address(arg_value);
     return retval;
 fail: ;
-    CPy_AddTraceback("faster_eth_utils/address.py", "to_checksum_address", 120, CPyStatic_address___globals);
+    CPy_AddTraceback("faster_eth_utils/address.py", "to_checksum_address", 121, CPyStatic_address___globals);
     return NULL;
 }
 
@@ -7095,7 +7095,7 @@ char CPyDef_address___is_checksum_address(PyObject *cpy_r_value) {
     char cpy_r_r4;
     cpy_r_r0 = CPyDef_address___is_hex_address(cpy_r_value);
     if (unlikely(cpy_r_r0 == 2)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "is_checksum_address", 143, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "is_checksum_address", 144, CPyStatic_address___globals);
         goto CPyL7;
     }
     if (cpy_r_r0) goto CPyL3;
@@ -7103,13 +7103,13 @@ char CPyDef_address___is_checksum_address(PyObject *cpy_r_value) {
 CPyL3: ;
     cpy_r_r1 = CPyDef_address___to_checksum_address(cpy_r_value);
     if (unlikely(cpy_r_r1 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "is_checksum_address", 145, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "is_checksum_address", 146, CPyStatic_address___globals);
         goto CPyL7;
     }
     cpy_r_r2 = PyObject_RichCompare(cpy_r_value, cpy_r_r1, 2);
     CPy_DECREF(cpy_r_r1);
     if (unlikely(cpy_r_r2 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "is_checksum_address", 145, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "is_checksum_address", 146, CPyStatic_address___globals);
         goto CPyL7;
     }
     if (unlikely(!PyBool_Check(cpy_r_r2))) {
@@ -7118,7 +7118,7 @@ CPyL3: ;
         cpy_r_r3 = cpy_r_r2 == Py_True;
     CPy_DECREF(cpy_r_r2);
     if (unlikely(cpy_r_r3 == 2)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "is_checksum_address", 145, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "is_checksum_address", 146, CPyStatic_address___globals);
         goto CPyL7;
     }
     return cpy_r_r3;
@@ -7143,7 +7143,7 @@ PyObject *CPyPy_address___is_checksum_address(PyObject *self, PyObject *const *a
     CPy_INCREF(retbox);
     return retbox;
 fail: ;
-    CPy_AddTraceback("faster_eth_utils/address.py", "is_checksum_address", 142, CPyStatic_address___globals);
+    CPy_AddTraceback("faster_eth_utils/address.py", "is_checksum_address", 143, CPyStatic_address___globals);
     return NULL;
 }
 
@@ -7169,7 +7169,7 @@ char CPyDef_address____is_checksum_formatted(PyObject *cpy_r_value) {
     char cpy_r_r21;
     cpy_r_r0 = CPyDef_hexadecimal___remove_0x_prefix(cpy_r_value);
     if (unlikely(cpy_r_r0 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "_is_checksum_formatted", 149, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "_is_checksum_formatted", 150, CPyStatic_address___globals);
         goto CPyL14;
     }
     cpy_r_r1 = CPyStatics[104]; /* 'islower' */
@@ -7177,7 +7177,7 @@ char CPyDef_address____is_checksum_formatted(PyObject *cpy_r_value) {
     cpy_r_r3 = (PyObject **)&cpy_r_r2;
     cpy_r_r4 = PyObject_VectorcallMethod(cpy_r_r1, cpy_r_r3, 9223372036854775809ULL, 0);
     if (unlikely(cpy_r_r4 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "_is_checksum_formatted", 151, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "_is_checksum_formatted", 152, CPyStatic_address___globals);
         goto CPyL15;
     }
     if (unlikely(!PyBool_Check(cpy_r_r4))) {
@@ -7186,7 +7186,7 @@ char CPyDef_address____is_checksum_formatted(PyObject *cpy_r_value) {
         cpy_r_r5 = cpy_r_r4 == Py_True;
     CPy_DECREF(cpy_r_r4);
     if (unlikely(cpy_r_r5 == 2)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "_is_checksum_formatted", 151, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "_is_checksum_formatted", 152, CPyStatic_address___globals);
         goto CPyL15;
     }
     cpy_r_r6 = cpy_r_r5 ^ 1;
@@ -7203,7 +7203,7 @@ CPyL5: ;
     cpy_r_r10 = (PyObject **)&cpy_r_r9;
     cpy_r_r11 = PyObject_VectorcallMethod(cpy_r_r8, cpy_r_r10, 9223372036854775809ULL, 0);
     if (unlikely(cpy_r_r11 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "_is_checksum_formatted", 152, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "_is_checksum_formatted", 153, CPyStatic_address___globals);
         goto CPyL15;
     }
     if (unlikely(!PyBool_Check(cpy_r_r11))) {
@@ -7212,7 +7212,7 @@ CPyL5: ;
         cpy_r_r12 = cpy_r_r11 == Py_True;
     CPy_DECREF(cpy_r_r11);
     if (unlikely(cpy_r_r12 == 2)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "_is_checksum_formatted", 152, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "_is_checksum_formatted", 153, CPyStatic_address___globals);
         goto CPyL15;
     }
     cpy_r_r13 = cpy_r_r12 ^ 1;
@@ -7229,7 +7229,7 @@ CPyL9: ;
     cpy_r_r17 = (PyObject **)&cpy_r_r16;
     cpy_r_r18 = PyObject_VectorcallMethod(cpy_r_r15, cpy_r_r17, 9223372036854775809ULL, 0);
     if (unlikely(cpy_r_r18 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "_is_checksum_formatted", 153, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "_is_checksum_formatted", 154, CPyStatic_address___globals);
         goto CPyL15;
     }
     CPy_DECREF(cpy_r_r0);
@@ -7239,7 +7239,7 @@ CPyL9: ;
         cpy_r_r19 = cpy_r_r18 == Py_True;
     CPy_DECREF(cpy_r_r18);
     if (unlikely(cpy_r_r19 == 2)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "_is_checksum_formatted", 153, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "_is_checksum_formatted", 154, CPyStatic_address___globals);
         goto CPyL14;
     }
     cpy_r_r20 = cpy_r_r19 ^ 1;
@@ -7278,7 +7278,7 @@ PyObject *CPyPy_address____is_checksum_formatted(PyObject *self, PyObject *const
     CPy_INCREF(retbox);
     return retbox;
 fail: ;
-    CPy_AddTraceback("faster_eth_utils/address.py", "_is_checksum_formatted", 148, CPyStatic_address___globals);
+    CPy_AddTraceback("faster_eth_utils/address.py", "_is_checksum_formatted", 149, CPyStatic_address___globals);
     return NULL;
 }
 
@@ -7289,7 +7289,7 @@ char CPyDef_address___is_checksum_formatted_address(PyObject *cpy_r_value) {
     char cpy_r_r3;
     cpy_r_r0 = CPyDef_address___is_hex_address(cpy_r_value);
     if (unlikely(cpy_r_r0 == 2)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "is_checksum_formatted_address", 158, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "is_checksum_formatted_address", 159, CPyStatic_address___globals);
         goto CPyL6;
     }
     if (cpy_r_r0) goto CPyL3;
@@ -7298,7 +7298,7 @@ char CPyDef_address___is_checksum_formatted_address(PyObject *cpy_r_value) {
 CPyL3: ;
     cpy_r_r2 = CPyDef_address____is_checksum_formatted(cpy_r_value);
     if (unlikely(cpy_r_r2 == 2)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "is_checksum_formatted_address", 158, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "is_checksum_formatted_address", 159, CPyStatic_address___globals);
         goto CPyL6;
     }
     cpy_r_r1 = cpy_r_r2;
@@ -7325,7 +7325,7 @@ PyObject *CPyPy_address___is_checksum_formatted_address(PyObject *self, PyObject
     CPy_INCREF(retbox);
     return retbox;
 fail: ;
-    CPy_AddTraceback("faster_eth_utils/address.py", "is_checksum_formatted_address", 157, CPyStatic_address___globals);
+    CPy_AddTraceback("faster_eth_utils/address.py", "is_checksum_formatted_address", 158, CPyStatic_address___globals);
     return NULL;
 }
 
@@ -7378,13 +7378,17 @@ char CPyDef_address_____top_level__(void) {
     PyObject *cpy_r_r47;
     PyObject *cpy_r_r48;
     PyObject *cpy_r_r49;
-    PyObject **cpy_r_r51;
+    PyObject *cpy_r_r50;
+    PyObject *cpy_r_r51;
     PyObject *cpy_r_r52;
     PyObject *cpy_r_r53;
-    PyObject *cpy_r_r54;
-    int32_t cpy_r_r55;
-    char cpy_r_r56;
-    char cpy_r_r57;
+    PyObject **cpy_r_r55;
+    PyObject *cpy_r_r56;
+    PyObject *cpy_r_r57;
+    PyObject *cpy_r_r58;
+    int32_t cpy_r_r59;
+    char cpy_r_r60;
+    char cpy_r_r61;
     cpy_r_r0 = CPyModule_builtins;
     cpy_r_r1 = (PyObject *)&_Py_NoneStruct;
     cpy_r_r2 = cpy_r_r0 != cpy_r_r1;
@@ -7393,7 +7397,7 @@ char CPyDef_address_____top_level__(void) {
     cpy_r_r4 = PyImport_Import(cpy_r_r3);
     if (unlikely(cpy_r_r4 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/address.py", "<module>", -1, CPyStatic_address___globals);
-        goto CPyL17;
+        goto CPyL18;
     }
     CPyModule_builtins = cpy_r_r4;
     CPy_INCREF(CPyModule_builtins);
@@ -7404,139 +7408,150 @@ CPyL3: ;
     cpy_r_r7 = (void *)&cpy_r_r6;
     int64_t cpy_r_r8[1] = {1};
     cpy_r_r9 = (void *)&cpy_r_r8;
-    cpy_r_r10 = CPyStatics[346]; /* (('re', 're', 're'),) */
+    cpy_r_r10 = CPyStatics[347]; /* (('re', 're', 're'),) */
     cpy_r_r11 = CPyStatic_address___globals;
     cpy_r_r12 = CPyStatics[107]; /* 'faster_eth_utils/address.py' */
     cpy_r_r13 = CPyStatics[70]; /* '<module>' */
     cpy_r_r14 = CPyImport_ImportMany(cpy_r_r10, cpy_r_r7, cpy_r_r11, cpy_r_r12, cpy_r_r13, cpy_r_r9);
-    if (!cpy_r_r14) goto CPyL17;
-    cpy_r_r15 = CPyStatics[347]; /* ('Any', 'Final', 'TypeGuard', 'Union', 'cast') */
+    if (!cpy_r_r14) goto CPyL18;
+    cpy_r_r15 = CPyStatics[348]; /* ('Any', 'Final', 'Union') */
     cpy_r_r16 = CPyStatics[81]; /* 'typing' */
     cpy_r_r17 = CPyStatic_address___globals;
     cpy_r_r18 = CPyImport_ImportFromMany(cpy_r_r16, cpy_r_r15, cpy_r_r15, cpy_r_r17);
     if (unlikely(cpy_r_r18 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/address.py", "<module>", 2, CPyStatic_address___globals);
-        goto CPyL17;
+        goto CPyL18;
     }
     CPyModule_typing = cpy_r_r18;
     CPy_INCREF(CPyModule_typing);
     CPy_DECREF(cpy_r_r18);
-    cpy_r_r19 = CPyStatics[348]; /* ('Address', 'AnyAddress', 'ChecksumAddress', 'HexAddress',
+    cpy_r_r19 = CPyStatics[349]; /* ('Address', 'AnyAddress', 'ChecksumAddress', 'HexAddress',
                                     'HexStr') */
     cpy_r_r20 = CPyStatics[91]; /* 'eth_typing' */
     cpy_r_r21 = CPyStatic_address___globals;
     cpy_r_r22 = CPyImport_ImportFromMany(cpy_r_r20, cpy_r_r19, cpy_r_r19, cpy_r_r21);
     if (unlikely(cpy_r_r22 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "<module>", 10, CPyStatic_address___globals);
-        goto CPyL17;
+        CPy_AddTraceback("faster_eth_utils/address.py", "<module>", 8, CPyStatic_address___globals);
+        goto CPyL18;
     }
     CPyModule_eth_typing = cpy_r_r22;
     CPy_INCREF(CPyModule_eth_typing);
     CPy_DECREF(cpy_r_r22);
-    cpy_r_r23 = CPyStatics[349]; /* ('hexstr_if_str', 'to_hex') */
-    cpy_r_r24 = CPyStatics[116]; /* 'faster_eth_utils.conversions' */
+    cpy_r_r23 = CPyStatics[350]; /* ('TypeGuard',) */
+    cpy_r_r24 = CPyStatics[115]; /* 'typing_extensions' */
     cpy_r_r25 = CPyStatic_address___globals;
     cpy_r_r26 = CPyImport_ImportFromMany(cpy_r_r24, cpy_r_r23, cpy_r_r23, cpy_r_r25);
     if (unlikely(cpy_r_r26 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "<module>", 18, CPyStatic_address___globals);
-        goto CPyL17;
+        CPy_AddTraceback("faster_eth_utils/address.py", "<module>", 15, CPyStatic_address___globals);
+        goto CPyL18;
     }
-    CPyModule_faster_eth_utils___conversions = cpy_r_r26;
-    CPy_INCREF(CPyModule_faster_eth_utils___conversions);
+    CPyModule_typing_extensions = cpy_r_r26;
+    CPy_INCREF(CPyModule_typing_extensions);
     CPy_DECREF(cpy_r_r26);
-    cpy_r_r27 = CPyStatics[345]; /* ('keccak',) */
-    cpy_r_r28 = CPyStatics[94]; /* 'faster_eth_utils.crypto' */
+    cpy_r_r27 = CPyStatics[351]; /* ('hexstr_if_str', 'to_hex') */
+    cpy_r_r28 = CPyStatics[117]; /* 'faster_eth_utils.conversions' */
     cpy_r_r29 = CPyStatic_address___globals;
     cpy_r_r30 = CPyImport_ImportFromMany(cpy_r_r28, cpy_r_r27, cpy_r_r27, cpy_r_r29);
     if (unlikely(cpy_r_r30 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "<module>", 22, CPyStatic_address___globals);
-        goto CPyL17;
+        CPy_AddTraceback("faster_eth_utils/address.py", "<module>", 19, CPyStatic_address___globals);
+        goto CPyL18;
     }
-    CPyModule_faster_eth_utils___crypto = cpy_r_r30;
-    CPy_INCREF(CPyModule_faster_eth_utils___crypto);
+    CPyModule_faster_eth_utils___conversions = cpy_r_r30;
+    CPy_INCREF(CPyModule_faster_eth_utils___conversions);
     CPy_DECREF(cpy_r_r30);
-    cpy_r_r31 = CPyStatics[350]; /* ('add_0x_prefix', 'decode_hex', 'encode_hex',
-                                    'remove_0x_prefix') */
-    cpy_r_r32 = CPyStatics[121]; /* 'faster_eth_utils.hexadecimal' */
+    cpy_r_r31 = CPyStatics[346]; /* ('keccak',) */
+    cpy_r_r32 = CPyStatics[94]; /* 'faster_eth_utils.crypto' */
     cpy_r_r33 = CPyStatic_address___globals;
     cpy_r_r34 = CPyImport_ImportFromMany(cpy_r_r32, cpy_r_r31, cpy_r_r31, cpy_r_r33);
     if (unlikely(cpy_r_r34 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "<module>", 25, CPyStatic_address___globals);
-        goto CPyL17;
+        CPy_AddTraceback("faster_eth_utils/address.py", "<module>", 23, CPyStatic_address___globals);
+        goto CPyL18;
     }
-    CPyModule_faster_eth_utils___hexadecimal = cpy_r_r34;
-    CPy_INCREF(CPyModule_faster_eth_utils___hexadecimal);
+    CPyModule_faster_eth_utils___crypto = cpy_r_r34;
+    CPy_INCREF(CPyModule_faster_eth_utils___crypto);
     CPy_DECREF(cpy_r_r34);
-    cpy_r_r35 = CPyStatics[351]; /* ('is_bytes', 'is_text') */
-    cpy_r_r36 = CPyStatics[93]; /* 'faster_eth_utils.types' */
+    cpy_r_r35 = CPyStatics[352]; /* ('add_0x_prefix', 'decode_hex', 'encode_hex',
+                                    'remove_0x_prefix') */
+    cpy_r_r36 = CPyStatics[122]; /* 'faster_eth_utils.hexadecimal' */
     cpy_r_r37 = CPyStatic_address___globals;
     cpy_r_r38 = CPyImport_ImportFromMany(cpy_r_r36, cpy_r_r35, cpy_r_r35, cpy_r_r37);
     if (unlikely(cpy_r_r38 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "<module>", 31, CPyStatic_address___globals);
-        goto CPyL17;
-    }
-    CPyModule_faster_eth_utils___types = cpy_r_r38;
-    CPy_INCREF(CPyModule_faster_eth_utils___types);
-    CPy_DECREF(cpy_r_r38);
-    cpy_r_r39 = CPyStatics[124]; /* '(0x)?[0-9a-f]{40}' */
-    cpy_r_r40 = CPyModule_re;
-    cpy_r_r41 = CPyStatics[125]; /* 'IGNORECASE' */
-    cpy_r_r42 = CPyObject_GetAttr(cpy_r_r40, cpy_r_r41);
-    if (unlikely(cpy_r_r42 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "<module>", 36, CPyStatic_address___globals);
-        goto CPyL17;
-    }
-    cpy_r_r43 = CPyModule_re;
-    cpy_r_r44 = CPyStatics[126]; /* 'ASCII' */
-    cpy_r_r45 = CPyObject_GetAttr(cpy_r_r43, cpy_r_r44);
-    if (unlikely(cpy_r_r45 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "<module>", 36, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "<module>", 26, CPyStatic_address___globals);
         goto CPyL18;
     }
-    cpy_r_r46 = PyNumber_Or(cpy_r_r42, cpy_r_r45);
+    CPyModule_faster_eth_utils___hexadecimal = cpy_r_r38;
+    CPy_INCREF(CPyModule_faster_eth_utils___hexadecimal);
+    CPy_DECREF(cpy_r_r38);
+    cpy_r_r39 = CPyStatics[353]; /* ('is_bytes', 'is_text') */
+    cpy_r_r40 = CPyStatics[93]; /* 'faster_eth_utils.types' */
+    cpy_r_r41 = CPyStatic_address___globals;
+    cpy_r_r42 = CPyImport_ImportFromMany(cpy_r_r40, cpy_r_r39, cpy_r_r39, cpy_r_r41);
+    if (unlikely(cpy_r_r42 == NULL)) {
+        CPy_AddTraceback("faster_eth_utils/address.py", "<module>", 32, CPyStatic_address___globals);
+        goto CPyL18;
+    }
+    CPyModule_faster_eth_utils___types = cpy_r_r42;
+    CPy_INCREF(CPyModule_faster_eth_utils___types);
     CPy_DECREF(cpy_r_r42);
-    CPy_DECREF(cpy_r_r45);
+    cpy_r_r43 = CPyStatics[125]; /* '(0x)?[0-9a-f]{40}' */
+    cpy_r_r44 = CPyModule_re;
+    cpy_r_r45 = CPyStatics[126]; /* 'IGNORECASE' */
+    cpy_r_r46 = CPyObject_GetAttr(cpy_r_r44, cpy_r_r45);
     if (unlikely(cpy_r_r46 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "<module>", 36, CPyStatic_address___globals);
-        goto CPyL17;
+        CPy_AddTraceback("faster_eth_utils/address.py", "<module>", 37, CPyStatic_address___globals);
+        goto CPyL18;
     }
     cpy_r_r47 = CPyModule_re;
-    cpy_r_r48 = CPyStatics[18]; /* 'compile' */
+    cpy_r_r48 = CPyStatics[127]; /* 'ASCII' */
     cpy_r_r49 = CPyObject_GetAttr(cpy_r_r47, cpy_r_r48);
     if (unlikely(cpy_r_r49 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "<module>", 36, CPyStatic_address___globals);
+        CPy_AddTraceback("faster_eth_utils/address.py", "<module>", 37, CPyStatic_address___globals);
         goto CPyL19;
     }
-    PyObject *cpy_r_r50[2] = {cpy_r_r39, cpy_r_r46};
-    cpy_r_r51 = (PyObject **)&cpy_r_r50;
-    cpy_r_r52 = PyObject_Vectorcall(cpy_r_r49, cpy_r_r51, 2, 0);
-    CPy_DECREF(cpy_r_r49);
-    if (unlikely(cpy_r_r52 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "<module>", 36, CPyStatic_address___globals);
-        goto CPyL19;
-    }
+    cpy_r_r50 = PyNumber_Or(cpy_r_r46, cpy_r_r49);
     CPy_DECREF(cpy_r_r46);
-    CPyStatic_address____HEX_ADDRESS_REGEXP = cpy_r_r52;
+    CPy_DECREF(cpy_r_r49);
+    if (unlikely(cpy_r_r50 == NULL)) {
+        CPy_AddTraceback("faster_eth_utils/address.py", "<module>", 37, CPyStatic_address___globals);
+        goto CPyL18;
+    }
+    cpy_r_r51 = CPyModule_re;
+    cpy_r_r52 = CPyStatics[18]; /* 'compile' */
+    cpy_r_r53 = CPyObject_GetAttr(cpy_r_r51, cpy_r_r52);
+    if (unlikely(cpy_r_r53 == NULL)) {
+        CPy_AddTraceback("faster_eth_utils/address.py", "<module>", 37, CPyStatic_address___globals);
+        goto CPyL20;
+    }
+    PyObject *cpy_r_r54[2] = {cpy_r_r43, cpy_r_r50};
+    cpy_r_r55 = (PyObject **)&cpy_r_r54;
+    cpy_r_r56 = PyObject_Vectorcall(cpy_r_r53, cpy_r_r55, 2, 0);
+    CPy_DECREF(cpy_r_r53);
+    if (unlikely(cpy_r_r56 == NULL)) {
+        CPy_AddTraceback("faster_eth_utils/address.py", "<module>", 37, CPyStatic_address___globals);
+        goto CPyL20;
+    }
+    CPy_DECREF(cpy_r_r50);
+    CPyStatic_address____HEX_ADDRESS_REGEXP = cpy_r_r56;
     CPy_INCREF(CPyStatic_address____HEX_ADDRESS_REGEXP);
-    cpy_r_r53 = CPyStatic_address___globals;
-    cpy_r_r54 = CPyStatics[127]; /* '_HEX_ADDRESS_REGEXP' */
-    cpy_r_r55 = CPyDict_SetItem(cpy_r_r53, cpy_r_r54, cpy_r_r52);
-    CPy_DECREF(cpy_r_r52);
-    cpy_r_r56 = cpy_r_r55 >= 0;
-    if (unlikely(!cpy_r_r56)) {
-        CPy_AddTraceback("faster_eth_utils/address.py", "<module>", 36, CPyStatic_address___globals);
-        goto CPyL17;
+    cpy_r_r57 = CPyStatic_address___globals;
+    cpy_r_r58 = CPyStatics[128]; /* '_HEX_ADDRESS_REGEXP' */
+    cpy_r_r59 = CPyDict_SetItem(cpy_r_r57, cpy_r_r58, cpy_r_r56);
+    CPy_DECREF(cpy_r_r56);
+    cpy_r_r60 = cpy_r_r59 >= 0;
+    if (unlikely(!cpy_r_r60)) {
+        CPy_AddTraceback("faster_eth_utils/address.py", "<module>", 37, CPyStatic_address___globals);
+        goto CPyL18;
     }
     return 1;
-CPyL17: ;
-    cpy_r_r57 = 2;
-    return cpy_r_r57;
 CPyL18: ;
-    CPy_DecRef(cpy_r_r42);
-    goto CPyL17;
+    cpy_r_r61 = 2;
+    return cpy_r_r61;
 CPyL19: ;
     CPy_DecRef(cpy_r_r46);
-    goto CPyL17;
+    goto CPyL18;
+CPyL20: ;
+    CPy_DecRef(cpy_r_r50);
+    goto CPyL18;
 }
 static PyMethodDef conversionsmodule_methods[] = {
     {"to_hex", (PyCFunction)CPyPy_conversions___to_hex, METH_FASTCALL | METH_KEYWORDS, NULL /* docstring */},
@@ -7752,12 +7767,12 @@ CPyL17: ;
         goto CPyL57;
     }
     if (!cpy_r_r21) goto CPyL22;
-    cpy_r_r22 = CPyStatics[128]; /* '0x1' */
+    cpy_r_r22 = CPyStatics[129]; /* '0x1' */
     CPy_INCREF(cpy_r_r22);
     cpy_r_r23 = cpy_r_r22;
     goto CPyL23;
 CPyL22: ;
-    cpy_r_r24 = CPyStatics[129]; /* '0x0' */
+    cpy_r_r24 = CPyStatics[130]; /* '0x0' */
     CPy_INCREF(cpy_r_r24);
     cpy_r_r23 = cpy_r_r24;
 CPyL23: ;
@@ -7765,7 +7780,7 @@ CPyL23: ;
 CPyL24: ;
     cpy_r_r25 = (PyObject *)&PyBytes_Type;
     cpy_r_r26 = CPyModule_builtins;
-    cpy_r_r27 = CPyStatics[130]; /* 'bytearray' */
+    cpy_r_r27 = CPyStatics[131]; /* 'bytearray' */
     cpy_r_r28 = CPyObject_GetAttr(cpy_r_r26, cpy_r_r27);
     if (unlikely(cpy_r_r28 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/conversions.py", "to_hex", 52, CPyStatic_conversions___globals);
@@ -7799,7 +7814,7 @@ CPyL24: ;
     return cpy_r_r34;
 CPyL29: ;
     cpy_r_r35 = CPyModule_builtins;
-    cpy_r_r36 = CPyStatics[131]; /* 'memoryview' */
+    cpy_r_r36 = CPyStatics[132]; /* 'memoryview' */
     cpy_r_r37 = CPyObject_GetAttr(cpy_r_r35, cpy_r_r36);
     if (unlikely(cpy_r_r37 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/conversions.py", "to_hex", 55, CPyStatic_conversions___globals);
@@ -7864,7 +7879,7 @@ __LL40: ;
     } else
         goto CPyL43;
 CPyL39: ;
-    cpy_r_r49 = CPyStatics[132]; /* ('Unsupported type: The primitive argument must be one '
+    cpy_r_r49 = CPyStatics[133]; /* ('Unsupported type: The primitive argument must be one '
                                     'of: bytes,bytearray, int or bool and not str') */
     cpy_r_r50 = CPyModule_builtins;
     cpy_r_r51 = CPyStatics[16]; /* 'TypeError' */
@@ -7909,7 +7924,7 @@ CPyL43: ;
         goto CPyL57;
     }
     cpy_r_r61 = CPyModule_builtins;
-    cpy_r_r62 = CPyStatics[133]; /* 'hex' */
+    cpy_r_r62 = CPyStatics[134]; /* 'hex' */
     cpy_r_r63 = CPyObject_GetAttr(cpy_r_r61, cpy_r_r62);
     if (unlikely(cpy_r_r63 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/conversions.py", "to_hex", 65, CPyStatic_conversions___globals);
@@ -7933,7 +7948,7 @@ CPyL43: ;
     }
     return cpy_r_r68;
 CPyL50: ;
-    cpy_r_r69 = CPyStatics[134]; /* "Unsupported type: '" */
+    cpy_r_r69 = CPyStatics[135]; /* "Unsupported type: '" */
     if (unlikely(cpy_r_primitive != Py_None)) {
         CPy_TypeError("None", cpy_r_primitive); cpy_r_r70 = 2;
     } else
@@ -7951,7 +7966,7 @@ CPyL50: ;
         CPy_AddTraceback("faster_eth_utils/conversions.py", "to_hex", 68, CPyStatic_conversions___globals);
         goto CPyL57;
     }
-    cpy_r_r74 = CPyStatics[135]; /* "'. Must be one of: bool, str, bytes, bytearray or int." */
+    cpy_r_r74 = CPyStatics[136]; /* "'. Must be one of: bool, str, bytes, bytearray or int." */
     cpy_r_r75 = CPyStr_Build(3, cpy_r_r69, cpy_r_r73, cpy_r_r74);
     CPy_DECREF(cpy_r_r73);
     if (unlikely(cpy_r_r75 == NULL)) {
@@ -8200,7 +8215,7 @@ CPyL6: ;
         goto CPyL50;
 CPyL7: ;
     cpy_r_r5 = (PyObject *)&PyLong_Type;
-    cpy_r_r6 = CPyStatics[321]; /* 16 */
+    cpy_r_r6 = CPyStatics[322]; /* 16 */
     PyObject *cpy_r_r7[2] = {cpy_r_hexstr, cpy_r_r6};
     cpy_r_r8 = (PyObject **)&cpy_r_r7;
     cpy_r_r9 = PyObject_Vectorcall(cpy_r_r5, cpy_r_r8, 2, 0);
@@ -8254,7 +8269,7 @@ CPyL11: ;
 CPyL15: ;
     cpy_r_r16 = (PyObject *)&PyBytes_Type;
     cpy_r_r17 = CPyModule_builtins;
-    cpy_r_r18 = CPyStatics[130]; /* 'bytearray' */
+    cpy_r_r18 = CPyStatics[131]; /* 'bytearray' */
     cpy_r_r19 = CPyObject_GetAttr(cpy_r_r17, cpy_r_r18);
     if (unlikely(cpy_r_r19 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/conversions.py", "to_int", 94, CPyStatic_conversions___globals);
@@ -8294,7 +8309,7 @@ CPyL15: ;
     return cpy_r_r26;
 CPyL21: ;
     cpy_r_r27 = CPyModule_builtins;
-    cpy_r_r28 = CPyStatics[131]; /* 'memoryview' */
+    cpy_r_r28 = CPyStatics[132]; /* 'memoryview' */
     cpy_r_r29 = CPyObject_GetAttr(cpy_r_r27, cpy_r_r28);
     if (unlikely(cpy_r_r29 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/conversions.py", "to_int", 96, CPyStatic_conversions___globals);
@@ -8345,7 +8360,7 @@ CPyL28: ;
     } else
         goto CPyL34;
 CPyL30: ;
-    cpy_r_r43 = CPyStatics[136]; /* 'Pass in strings with keyword hexstr or text' */
+    cpy_r_r43 = CPyStatics[137]; /* 'Pass in strings with keyword hexstr or text' */
     cpy_r_r44 = CPyModule_builtins;
     cpy_r_r45 = CPyStatics[16]; /* 'TypeError' */
     cpy_r_r46 = CPyObject_GetAttr(cpy_r_r44, cpy_r_r45);
@@ -8403,7 +8418,7 @@ CPyL34: ;
     }
     return cpy_r_r57;
 CPyL38: ;
-    cpy_r_r58 = CPyStatics[137]; /* ('Invalid type. Expected one of '
+    cpy_r_r58 = CPyStatics[138]; /* ('Invalid type. Expected one of '
                                     'int/bool/str/bytes/bytearray. Got ') */
     if (unlikely(cpy_r_primitive != Py_None)) {
         CPy_TypeError("None", cpy_r_primitive); cpy_r_r59 = 2;
@@ -8681,26 +8696,26 @@ CPyL8: ;
         goto CPyL49;
     }
     if (!cpy_r_r7) goto CPyL11;
-    cpy_r_r8 = CPyStatics[317]; /* b'\x01' */
+    cpy_r_r8 = CPyStatics[318]; /* b'\x01' */
     CPy_INCREF(cpy_r_r8);
     cpy_r_r9 = cpy_r_r8;
     goto CPyL12;
 CPyL11: ;
-    cpy_r_r10 = CPyStatics[318]; /* b'\x00' */
+    cpy_r_r10 = CPyStatics[319]; /* b'\x00' */
     CPy_INCREF(cpy_r_r10);
     cpy_r_r9 = cpy_r_r10;
 CPyL12: ;
     return cpy_r_r9;
 CPyL13: ;
     cpy_r_r11 = CPyModule_builtins;
-    cpy_r_r12 = CPyStatics[130]; /* 'bytearray' */
+    cpy_r_r12 = CPyStatics[131]; /* 'bytearray' */
     cpy_r_r13 = CPyObject_GetAttr(cpy_r_r11, cpy_r_r12);
     if (unlikely(cpy_r_r13 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/conversions.py", "to_bytes", 116, CPyStatic_conversions___globals);
         goto CPyL53;
     }
     cpy_r_r14 = CPyModule_builtins;
-    cpy_r_r15 = CPyStatics[131]; /* 'memoryview' */
+    cpy_r_r15 = CPyStatics[132]; /* 'memoryview' */
     cpy_r_r16 = CPyObject_GetAttr(cpy_r_r14, cpy_r_r15);
     if (unlikely(cpy_r_r16 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/conversions.py", "to_bytes", 116, CPyStatic_conversions___globals);
@@ -8829,7 +8844,7 @@ CPyL31: ;
     cpy_r_r48 = cpy_r_r47 != 0;
     CPyTagged_DECREF(cpy_r_r47);
     if (!cpy_r_r48) goto CPyL38;
-    cpy_r_r49 = CPyStatics[129]; /* '0x0' */
+    cpy_r_r49 = CPyStatics[130]; /* '0x0' */
     cpy_r_r50 = CPyDef_hexadecimal___remove_0x_prefix(cpy_r_hexstr);
     CPy_DECREF(cpy_r_hexstr);
     if (unlikely(cpy_r_r50 == NULL)) {
@@ -8881,7 +8896,7 @@ CPyL41: ;
     }
     return cpy_r_r58;
 CPyL45: ;
-    cpy_r_r59 = CPyStatics[138]; /* ('expected a bool, int, byte or bytearray in first arg, '
+    cpy_r_r59 = CPyStatics[139]; /* ('expected a bool, int, byte or bytearray in first arg, '
                                     'or keyword of hexstr or text') */
     cpy_r_r60 = CPyModule_builtins;
     cpy_r_r61 = CPyStatics[16]; /* 'TypeError' */
@@ -9141,7 +9156,7 @@ CPyL7: ;
         CPy_AddTraceback("faster_eth_utils/conversions.py", "to_text", 140, CPyStatic_conversions___globals);
         goto CPyL41;
     }
-    cpy_r_r8 = CPyStatics[139]; /* 'utf-8' */
+    cpy_r_r8 = CPyStatics[140]; /* 'utf-8' */
     cpy_r_r9 = CPy_Decode(cpy_r_r7, cpy_r_r8, NULL);
     CPy_DECREF(cpy_r_r7);
     if (unlikely(cpy_r_r9 == NULL)) {
@@ -9186,7 +9201,7 @@ CPyL13: ;
 CPyL17: ;
     cpy_r_r20 = (PyObject *)&PyBytes_Type;
     cpy_r_r21 = CPyModule_builtins;
-    cpy_r_r22 = CPyStatics[130]; /* 'bytearray' */
+    cpy_r_r22 = CPyStatics[131]; /* 'bytearray' */
     cpy_r_r23 = CPyObject_GetAttr(cpy_r_r21, cpy_r_r22);
     if (unlikely(cpy_r_r23 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/conversions.py", "to_text", 145, CPyStatic_conversions___globals);
@@ -9211,9 +9226,9 @@ CPyL17: ;
     }
     cpy_r_r28 = cpy_r_r26;
     if (!cpy_r_r28) goto CPyL24;
-    cpy_r_r29 = CPyStatics[139]; /* 'utf-8' */
+    cpy_r_r29 = CPyStatics[140]; /* 'utf-8' */
     cpy_r_r30 = cpy_r_primitive;
-    cpy_r_r31 = CPyStatics[140]; /* 'decode' */
+    cpy_r_r31 = CPyStatics[141]; /* 'decode' */
     PyObject *cpy_r_r32[2] = {cpy_r_r30, cpy_r_r29};
     cpy_r_r33 = (PyObject **)&cpy_r_r32;
     cpy_r_r34 = PyObject_VectorcallMethod(cpy_r_r31, cpy_r_r33, 9223372036854775810ULL, 0);
@@ -9231,7 +9246,7 @@ CPyL17: ;
     return cpy_r_r35;
 CPyL24: ;
     cpy_r_r36 = CPyModule_builtins;
-    cpy_r_r37 = CPyStatics[131]; /* 'memoryview' */
+    cpy_r_r37 = CPyStatics[132]; /* 'memoryview' */
     cpy_r_r38 = CPyObject_GetAttr(cpy_r_r36, cpy_r_r37);
     if (unlikely(cpy_r_r38 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/conversions.py", "to_text", 147, CPyStatic_conversions___globals);
@@ -9261,7 +9276,7 @@ CPyL24: ;
         CPy_TypeErrorTraceback("faster_eth_utils/conversions.py", "to_text", 148, CPyStatic_conversions___globals, "bytes", cpy_r_r45);
         goto CPyL41;
     }
-    cpy_r_r47 = CPyStatics[139]; /* 'utf-8' */
+    cpy_r_r47 = CPyStatics[140]; /* 'utf-8' */
     cpy_r_r48 = CPy_Decode(cpy_r_r46, cpy_r_r47, NULL);
     CPy_DECREF(cpy_r_r46);
     if (unlikely(cpy_r_r48 == NULL)) {
@@ -9305,7 +9320,7 @@ CPyL31: ;
     }
     return cpy_r_r57;
 CPyL37: ;
-    cpy_r_r58 = CPyStatics[141]; /* 'Expected an int, bytes, bytearray or hexstr.' */
+    cpy_r_r58 = CPyStatics[142]; /* 'Expected an int, bytes, bytearray or hexstr.' */
     cpy_r_r59 = CPyModule_builtins;
     cpy_r_r60 = CPyStatics[16]; /* 'TypeError' */
     cpy_r_r61 = CPyObject_GetAttr(cpy_r_r59, cpy_r_r60);
@@ -9481,7 +9496,7 @@ PyObject *CPyDef_conversions___text_if_str(PyObject *cpy_r_to_type, PyObject *cp
     }
     PyObject *cpy_r_r5[1] = {cpy_r_r4};
     cpy_r_r6 = (PyObject **)&cpy_r_r5;
-    cpy_r_r7 = CPyStatics[336]; /* ('text',) */
+    cpy_r_r7 = CPyStatics[337]; /* ('text',) */
     cpy_r_r8 = PyObject_Vectorcall(cpy_r_to_type, cpy_r_r6, 0, cpy_r_r7);
     if (unlikely(cpy_r_r8 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/conversions.py", "text_if_str", 166, CPyStatic_conversions___globals);
@@ -9638,7 +9653,7 @@ PyObject *CPyDef_conversions___hexstr_if_str(PyObject *cpy_r_to_type, PyObject *
         goto CPyL22;
     }
     if (cpy_r_r10) goto CPyL16;
-    cpy_r_r11 = CPyStatics[142]; /* 'when sending a str, it must be a hex string. Got: ' */
+    cpy_r_r11 = CPyStatics[143]; /* 'when sending a str, it must be a hex string. Got: ' */
     CPy_INCREF(cpy_r_hexstr_or_primitive);
     if (likely(PyUnicode_Check(cpy_r_hexstr_or_primitive)))
         cpy_r_r12 = cpy_r_hexstr_or_primitive;
@@ -9691,7 +9706,7 @@ CPyL16: ;
     }
     PyObject *cpy_r_r22[1] = {cpy_r_r21};
     cpy_r_r23 = (PyObject **)&cpy_r_r22;
-    cpy_r_r24 = CPyStatics[352]; /* ('hexstr',) */
+    cpy_r_r24 = CPyStatics[354]; /* ('hexstr',) */
     cpy_r_r25 = PyObject_Vectorcall(cpy_r_to_type, cpy_r_r23, 0, cpy_r_r24);
     if (unlikely(cpy_r_r25 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/conversions.py", "hexstr_if_str", 189, CPyStatic_conversions___globals);
@@ -9847,7 +9862,7 @@ char CPyDef_conversions_____top_level__(void) {
     CPy_INCREF(CPyModule_builtins);
     CPy_DECREF(cpy_r_r4);
 CPyL3: ;
-    cpy_r_r5 = CPyStatics[353]; /* ('Callable', 'Optional', 'TypeVar', 'Union') */
+    cpy_r_r5 = CPyStatics[355]; /* ('Callable', 'Optional', 'TypeVar', 'Union') */
     cpy_r_r6 = CPyStatics[81]; /* 'typing' */
     cpy_r_r7 = CPyStatic_conversions___globals;
     cpy_r_r8 = CPyImport_ImportFromMany(cpy_r_r6, cpy_r_r5, cpy_r_r5, cpy_r_r7);
@@ -9858,7 +9873,7 @@ CPyL3: ;
     CPyModule_typing = cpy_r_r8;
     CPy_INCREF(CPyModule_typing);
     CPy_DECREF(cpy_r_r8);
-    cpy_r_r9 = CPyStatics[354]; /* ('HexStr', 'Primitives') */
+    cpy_r_r9 = CPyStatics[356]; /* ('HexStr', 'Primitives') */
     cpy_r_r10 = CPyStatics[91]; /* 'eth_typing' */
     cpy_r_r11 = CPyStatic_conversions___globals;
     cpy_r_r12 = CPyImport_ImportFromMany(cpy_r_r10, cpy_r_r9, cpy_r_r9, cpy_r_r11);
@@ -9869,8 +9884,8 @@ CPyL3: ;
     CPyModule_eth_typing = cpy_r_r12;
     CPy_INCREF(CPyModule_eth_typing);
     CPy_DECREF(cpy_r_r12);
-    cpy_r_r13 = CPyStatics[355]; /* ('big_endian_to_int', 'int_to_big_endian') */
-    cpy_r_r14 = CPyStatics[149]; /* 'faster_eth_utils.encoding' */
+    cpy_r_r13 = CPyStatics[357]; /* ('big_endian_to_int', 'int_to_big_endian') */
+    cpy_r_r14 = CPyStatics[150]; /* 'faster_eth_utils.encoding' */
     cpy_r_r15 = CPyStatic_conversions___globals;
     cpy_r_r16 = CPyImport_ImportFromMany(cpy_r_r14, cpy_r_r13, cpy_r_r13, cpy_r_r15);
     if (unlikely(cpy_r_r16 == NULL)) {
@@ -9880,9 +9895,9 @@ CPyL3: ;
     CPyModule_faster_eth_utils___encoding = cpy_r_r16;
     CPy_INCREF(CPyModule_faster_eth_utils___encoding);
     CPy_DECREF(cpy_r_r16);
-    cpy_r_r17 = CPyStatics[356]; /* ('add_0x_prefix', 'decode_hex', 'encode_hex', 'is_hexstr',
+    cpy_r_r17 = CPyStatics[358]; /* ('add_0x_prefix', 'decode_hex', 'encode_hex', 'is_hexstr',
                                     'remove_0x_prefix') */
-    cpy_r_r18 = CPyStatics[121]; /* 'faster_eth_utils.hexadecimal' */
+    cpy_r_r18 = CPyStatics[122]; /* 'faster_eth_utils.hexadecimal' */
     cpy_r_r19 = CPyStatic_conversions___globals;
     cpy_r_r20 = CPyImport_ImportFromMany(cpy_r_r18, cpy_r_r17, cpy_r_r17, cpy_r_r19);
     if (unlikely(cpy_r_r20 == NULL)) {
@@ -9892,7 +9907,7 @@ CPyL3: ;
     CPyModule_faster_eth_utils___hexadecimal = cpy_r_r20;
     CPy_INCREF(CPyModule_faster_eth_utils___hexadecimal);
     CPy_DECREF(cpy_r_r20);
-    cpy_r_r21 = CPyStatics[357]; /* ('is_string',) */
+    cpy_r_r21 = CPyStatics[359]; /* ('is_string',) */
     cpy_r_r22 = CPyStatics[93]; /* 'faster_eth_utils.types' */
     cpy_r_r23 = CPyStatic_conversions___globals;
     cpy_r_r24 = CPyImport_ImportFromMany(cpy_r_r22, cpy_r_r21, cpy_r_r21, cpy_r_r23);
@@ -9903,9 +9918,9 @@ CPyL3: ;
     CPyModule_faster_eth_utils___types = cpy_r_r24;
     CPy_INCREF(CPyModule_faster_eth_utils___types);
     CPy_DECREF(cpy_r_r24);
-    cpy_r_r25 = CPyStatics[152]; /* 'T' */
+    cpy_r_r25 = CPyStatics[153]; /* 'T' */
     cpy_r_r26 = CPyStatic_conversions___globals;
-    cpy_r_r27 = CPyStatics[145]; /* 'TypeVar' */
+    cpy_r_r27 = CPyStatics[146]; /* 'TypeVar' */
     cpy_r_r28 = CPyDict_GetItem(cpy_r_r26, cpy_r_r27);
     if (unlikely(cpy_r_r28 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/conversions.py", "<module>", 28, CPyStatic_conversions___globals);
@@ -9920,7 +9935,7 @@ CPyL3: ;
         goto CPyL18;
     }
     cpy_r_r32 = CPyStatic_conversions___globals;
-    cpy_r_r33 = CPyStatics[152]; /* 'T' */
+    cpy_r_r33 = CPyStatics[153]; /* 'T' */
     cpy_r_r34 = CPyDict_SetItem(cpy_r_r32, cpy_r_r33, cpy_r_r31);
     CPy_DECREF(cpy_r_r31);
     cpy_r_r35 = cpy_r_r34 >= 0;
@@ -9936,21 +9951,21 @@ CPyL3: ;
         goto CPyL18;
     }
     cpy_r_r39 = CPyStatic_conversions___globals;
-    cpy_r_r40 = CPyStatics[146]; /* 'Primitives' */
+    cpy_r_r40 = CPyStatics[147]; /* 'Primitives' */
     cpy_r_r41 = CPyDict_GetItem(cpy_r_r39, cpy_r_r40);
     if (unlikely(cpy_r_r41 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/conversions.py", "<module>", 30, CPyStatic_conversions___globals);
         goto CPyL19;
     }
     cpy_r_r42 = CPyModule_builtins;
-    cpy_r_r43 = CPyStatics[130]; /* 'bytearray' */
+    cpy_r_r43 = CPyStatics[131]; /* 'bytearray' */
     cpy_r_r44 = CPyObject_GetAttr(cpy_r_r42, cpy_r_r43);
     if (unlikely(cpy_r_r44 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/conversions.py", "<module>", 30, CPyStatic_conversions___globals);
         goto CPyL20;
     }
     cpy_r_r45 = CPyModule_builtins;
-    cpy_r_r46 = CPyStatics[131]; /* 'memoryview' */
+    cpy_r_r46 = CPyStatics[132]; /* 'memoryview' */
     cpy_r_r47 = CPyObject_GetAttr(cpy_r_r45, cpy_r_r46);
     if (unlikely(cpy_r_r47 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/conversions.py", "<module>", 30, CPyStatic_conversions___globals);
@@ -9976,7 +9991,7 @@ CPyL3: ;
         goto CPyL18;
     }
     cpy_r_r51 = CPyStatic_conversions___globals;
-    cpy_r_r52 = CPyStatics[153]; /* 'BytesLike' */
+    cpy_r_r52 = CPyStatics[154]; /* 'BytesLike' */
     cpy_r_r53 = CPyDict_SetItem(cpy_r_r51, cpy_r_r52, cpy_r_r50);
     CPy_DECREF(cpy_r_r50);
     cpy_r_r54 = cpy_r_r53 >= 0;
@@ -11597,7 +11612,7 @@ char CPyDef_currency___denoms_____mypyc_defaults_setup(PyObject *cpy_r___mypyc_s
     CPyTagged cpy_r_r252;
     char cpy_r_r253;
     cpy_r_r0 = CPyStatic_currency___globals;
-    cpy_r_r1 = CPyStatics[154]; /* 'units' */
+    cpy_r_r1 = CPyStatics[155]; /* 'units' */
     cpy_r_r2 = CPyDict_GetItem(cpy_r_r0, cpy_r_r1);
     if (cpy_r_r2 == NULL) goto CPyL116;
     if (likely(PyDict_Check(cpy_r_r2)))
@@ -11607,7 +11622,7 @@ char CPyDef_currency___denoms_____mypyc_defaults_setup(PyObject *cpy_r___mypyc_s
         cpy_r_r3 = NULL;
     }
     if (cpy_r_r3 == NULL) goto CPyL116;
-    cpy_r_r4 = CPyStatics[155]; /* 'wei' */
+    cpy_r_r4 = CPyStatics[156]; /* 'wei' */
     cpy_r_r5 = CPyDict_GetItem(cpy_r_r3, cpy_r_r4);
     CPy_DECREF(cpy_r_r3);
     if (cpy_r_r5 == NULL) goto CPyL116;
@@ -11626,7 +11641,7 @@ char CPyDef_currency___denoms_____mypyc_defaults_setup(PyObject *cpy_r___mypyc_s
     if (cpy_r_r10 == CPY_INT_TAG) goto CPyL116;
     ((faster_eth_utils___currency___denomsObject *)cpy_r___mypyc_self__)->_wei = cpy_r_r10;
     cpy_r_r11 = CPyStatic_currency___globals;
-    cpy_r_r12 = CPyStatics[154]; /* 'units' */
+    cpy_r_r12 = CPyStatics[155]; /* 'units' */
     cpy_r_r13 = CPyDict_GetItem(cpy_r_r11, cpy_r_r12);
     if (cpy_r_r13 == NULL) goto CPyL116;
     if (likely(PyDict_Check(cpy_r_r13)))
@@ -11636,7 +11651,7 @@ char CPyDef_currency___denoms_____mypyc_defaults_setup(PyObject *cpy_r___mypyc_s
         cpy_r_r14 = NULL;
     }
     if (cpy_r_r14 == NULL) goto CPyL116;
-    cpy_r_r15 = CPyStatics[156]; /* 'kwei' */
+    cpy_r_r15 = CPyStatics[157]; /* 'kwei' */
     cpy_r_r16 = CPyDict_GetItem(cpy_r_r14, cpy_r_r15);
     CPy_DECREF(cpy_r_r14);
     if (cpy_r_r16 == NULL) goto CPyL116;
@@ -11655,7 +11670,7 @@ char CPyDef_currency___denoms_____mypyc_defaults_setup(PyObject *cpy_r___mypyc_s
     if (cpy_r_r21 == CPY_INT_TAG) goto CPyL116;
     ((faster_eth_utils___currency___denomsObject *)cpy_r___mypyc_self__)->_kwei = cpy_r_r21;
     cpy_r_r22 = CPyStatic_currency___globals;
-    cpy_r_r23 = CPyStatics[154]; /* 'units' */
+    cpy_r_r23 = CPyStatics[155]; /* 'units' */
     cpy_r_r24 = CPyDict_GetItem(cpy_r_r22, cpy_r_r23);
     if (cpy_r_r24 == NULL) goto CPyL116;
     if (likely(PyDict_Check(cpy_r_r24)))
@@ -11665,7 +11680,7 @@ char CPyDef_currency___denoms_____mypyc_defaults_setup(PyObject *cpy_r___mypyc_s
         cpy_r_r25 = NULL;
     }
     if (cpy_r_r25 == NULL) goto CPyL116;
-    cpy_r_r26 = CPyStatics[157]; /* 'babbage' */
+    cpy_r_r26 = CPyStatics[158]; /* 'babbage' */
     cpy_r_r27 = CPyDict_GetItem(cpy_r_r25, cpy_r_r26);
     CPy_DECREF(cpy_r_r25);
     if (cpy_r_r27 == NULL) goto CPyL116;
@@ -11684,7 +11699,7 @@ char CPyDef_currency___denoms_____mypyc_defaults_setup(PyObject *cpy_r___mypyc_s
     if (cpy_r_r32 == CPY_INT_TAG) goto CPyL116;
     ((faster_eth_utils___currency___denomsObject *)cpy_r___mypyc_self__)->_babbage = cpy_r_r32;
     cpy_r_r33 = CPyStatic_currency___globals;
-    cpy_r_r34 = CPyStatics[154]; /* 'units' */
+    cpy_r_r34 = CPyStatics[155]; /* 'units' */
     cpy_r_r35 = CPyDict_GetItem(cpy_r_r33, cpy_r_r34);
     if (cpy_r_r35 == NULL) goto CPyL116;
     if (likely(PyDict_Check(cpy_r_r35)))
@@ -11694,7 +11709,7 @@ char CPyDef_currency___denoms_____mypyc_defaults_setup(PyObject *cpy_r___mypyc_s
         cpy_r_r36 = NULL;
     }
     if (cpy_r_r36 == NULL) goto CPyL116;
-    cpy_r_r37 = CPyStatics[158]; /* 'femtoether' */
+    cpy_r_r37 = CPyStatics[159]; /* 'femtoether' */
     cpy_r_r38 = CPyDict_GetItem(cpy_r_r36, cpy_r_r37);
     CPy_DECREF(cpy_r_r36);
     if (cpy_r_r38 == NULL) goto CPyL116;
@@ -11713,7 +11728,7 @@ char CPyDef_currency___denoms_____mypyc_defaults_setup(PyObject *cpy_r___mypyc_s
     if (cpy_r_r43 == CPY_INT_TAG) goto CPyL116;
     ((faster_eth_utils___currency___denomsObject *)cpy_r___mypyc_self__)->_femtoether = cpy_r_r43;
     cpy_r_r44 = CPyStatic_currency___globals;
-    cpy_r_r45 = CPyStatics[154]; /* 'units' */
+    cpy_r_r45 = CPyStatics[155]; /* 'units' */
     cpy_r_r46 = CPyDict_GetItem(cpy_r_r44, cpy_r_r45);
     if (cpy_r_r46 == NULL) goto CPyL116;
     if (likely(PyDict_Check(cpy_r_r46)))
@@ -11723,7 +11738,7 @@ char CPyDef_currency___denoms_____mypyc_defaults_setup(PyObject *cpy_r___mypyc_s
         cpy_r_r47 = NULL;
     }
     if (cpy_r_r47 == NULL) goto CPyL116;
-    cpy_r_r48 = CPyStatics[159]; /* 'mwei' */
+    cpy_r_r48 = CPyStatics[160]; /* 'mwei' */
     cpy_r_r49 = CPyDict_GetItem(cpy_r_r47, cpy_r_r48);
     CPy_DECREF(cpy_r_r47);
     if (cpy_r_r49 == NULL) goto CPyL116;
@@ -11742,7 +11757,7 @@ char CPyDef_currency___denoms_____mypyc_defaults_setup(PyObject *cpy_r___mypyc_s
     if (cpy_r_r54 == CPY_INT_TAG) goto CPyL116;
     ((faster_eth_utils___currency___denomsObject *)cpy_r___mypyc_self__)->_mwei = cpy_r_r54;
     cpy_r_r55 = CPyStatic_currency___globals;
-    cpy_r_r56 = CPyStatics[154]; /* 'units' */
+    cpy_r_r56 = CPyStatics[155]; /* 'units' */
     cpy_r_r57 = CPyDict_GetItem(cpy_r_r55, cpy_r_r56);
     if (cpy_r_r57 == NULL) goto CPyL116;
     if (likely(PyDict_Check(cpy_r_r57)))
@@ -11752,7 +11767,7 @@ char CPyDef_currency___denoms_____mypyc_defaults_setup(PyObject *cpy_r___mypyc_s
         cpy_r_r58 = NULL;
     }
     if (cpy_r_r58 == NULL) goto CPyL116;
-    cpy_r_r59 = CPyStatics[160]; /* 'lovelace' */
+    cpy_r_r59 = CPyStatics[161]; /* 'lovelace' */
     cpy_r_r60 = CPyDict_GetItem(cpy_r_r58, cpy_r_r59);
     CPy_DECREF(cpy_r_r58);
     if (cpy_r_r60 == NULL) goto CPyL116;
@@ -11771,7 +11786,7 @@ char CPyDef_currency___denoms_____mypyc_defaults_setup(PyObject *cpy_r___mypyc_s
     if (cpy_r_r65 == CPY_INT_TAG) goto CPyL116;
     ((faster_eth_utils___currency___denomsObject *)cpy_r___mypyc_self__)->_lovelace = cpy_r_r65;
     cpy_r_r66 = CPyStatic_currency___globals;
-    cpy_r_r67 = CPyStatics[154]; /* 'units' */
+    cpy_r_r67 = CPyStatics[155]; /* 'units' */
     cpy_r_r68 = CPyDict_GetItem(cpy_r_r66, cpy_r_r67);
     if (cpy_r_r68 == NULL) goto CPyL116;
     if (likely(PyDict_Check(cpy_r_r68)))
@@ -11781,7 +11796,7 @@ char CPyDef_currency___denoms_____mypyc_defaults_setup(PyObject *cpy_r___mypyc_s
         cpy_r_r69 = NULL;
     }
     if (cpy_r_r69 == NULL) goto CPyL116;
-    cpy_r_r70 = CPyStatics[161]; /* 'picoether' */
+    cpy_r_r70 = CPyStatics[162]; /* 'picoether' */
     cpy_r_r71 = CPyDict_GetItem(cpy_r_r69, cpy_r_r70);
     CPy_DECREF(cpy_r_r69);
     if (cpy_r_r71 == NULL) goto CPyL116;
@@ -11800,7 +11815,7 @@ char CPyDef_currency___denoms_____mypyc_defaults_setup(PyObject *cpy_r___mypyc_s
     if (cpy_r_r76 == CPY_INT_TAG) goto CPyL116;
     ((faster_eth_utils___currency___denomsObject *)cpy_r___mypyc_self__)->_picoether = cpy_r_r76;
     cpy_r_r77 = CPyStatic_currency___globals;
-    cpy_r_r78 = CPyStatics[154]; /* 'units' */
+    cpy_r_r78 = CPyStatics[155]; /* 'units' */
     cpy_r_r79 = CPyDict_GetItem(cpy_r_r77, cpy_r_r78);
     if (cpy_r_r79 == NULL) goto CPyL116;
     if (likely(PyDict_Check(cpy_r_r79)))
@@ -11810,7 +11825,7 @@ char CPyDef_currency___denoms_____mypyc_defaults_setup(PyObject *cpy_r___mypyc_s
         cpy_r_r80 = NULL;
     }
     if (cpy_r_r80 == NULL) goto CPyL116;
-    cpy_r_r81 = CPyStatics[162]; /* 'gwei' */
+    cpy_r_r81 = CPyStatics[163]; /* 'gwei' */
     cpy_r_r82 = CPyDict_GetItem(cpy_r_r80, cpy_r_r81);
     CPy_DECREF(cpy_r_r80);
     if (cpy_r_r82 == NULL) goto CPyL116;
@@ -11829,7 +11844,7 @@ char CPyDef_currency___denoms_____mypyc_defaults_setup(PyObject *cpy_r___mypyc_s
     if (cpy_r_r87 == CPY_INT_TAG) goto CPyL116;
     ((faster_eth_utils___currency___denomsObject *)cpy_r___mypyc_self__)->_gwei = cpy_r_r87;
     cpy_r_r88 = CPyStatic_currency___globals;
-    cpy_r_r89 = CPyStatics[154]; /* 'units' */
+    cpy_r_r89 = CPyStatics[155]; /* 'units' */
     cpy_r_r90 = CPyDict_GetItem(cpy_r_r88, cpy_r_r89);
     if (cpy_r_r90 == NULL) goto CPyL116;
     if (likely(PyDict_Check(cpy_r_r90)))
@@ -11839,7 +11854,7 @@ char CPyDef_currency___denoms_____mypyc_defaults_setup(PyObject *cpy_r___mypyc_s
         cpy_r_r91 = NULL;
     }
     if (cpy_r_r91 == NULL) goto CPyL116;
-    cpy_r_r92 = CPyStatics[163]; /* 'shannon' */
+    cpy_r_r92 = CPyStatics[164]; /* 'shannon' */
     cpy_r_r93 = CPyDict_GetItem(cpy_r_r91, cpy_r_r92);
     CPy_DECREF(cpy_r_r91);
     if (cpy_r_r93 == NULL) goto CPyL116;
@@ -11858,7 +11873,7 @@ char CPyDef_currency___denoms_____mypyc_defaults_setup(PyObject *cpy_r___mypyc_s
     if (cpy_r_r98 == CPY_INT_TAG) goto CPyL116;
     ((faster_eth_utils___currency___denomsObject *)cpy_r___mypyc_self__)->_shannon = cpy_r_r98;
     cpy_r_r99 = CPyStatic_currency___globals;
-    cpy_r_r100 = CPyStatics[154]; /* 'units' */
+    cpy_r_r100 = CPyStatics[155]; /* 'units' */
     cpy_r_r101 = CPyDict_GetItem(cpy_r_r99, cpy_r_r100);
     if (cpy_r_r101 == NULL) goto CPyL116;
     if (likely(PyDict_Check(cpy_r_r101)))
@@ -11868,7 +11883,7 @@ char CPyDef_currency___denoms_____mypyc_defaults_setup(PyObject *cpy_r___mypyc_s
         cpy_r_r102 = NULL;
     }
     if (cpy_r_r102 == NULL) goto CPyL116;
-    cpy_r_r103 = CPyStatics[164]; /* 'nanoether' */
+    cpy_r_r103 = CPyStatics[165]; /* 'nanoether' */
     cpy_r_r104 = CPyDict_GetItem(cpy_r_r102, cpy_r_r103);
     CPy_DECREF(cpy_r_r102);
     if (cpy_r_r104 == NULL) goto CPyL116;
@@ -11887,7 +11902,7 @@ char CPyDef_currency___denoms_____mypyc_defaults_setup(PyObject *cpy_r___mypyc_s
     if (cpy_r_r109 == CPY_INT_TAG) goto CPyL116;
     ((faster_eth_utils___currency___denomsObject *)cpy_r___mypyc_self__)->_nanoether = cpy_r_r109;
     cpy_r_r110 = CPyStatic_currency___globals;
-    cpy_r_r111 = CPyStatics[154]; /* 'units' */
+    cpy_r_r111 = CPyStatics[155]; /* 'units' */
     cpy_r_r112 = CPyDict_GetItem(cpy_r_r110, cpy_r_r111);
     if (cpy_r_r112 == NULL) goto CPyL116;
     if (likely(PyDict_Check(cpy_r_r112)))
@@ -11897,7 +11912,7 @@ char CPyDef_currency___denoms_____mypyc_defaults_setup(PyObject *cpy_r___mypyc_s
         cpy_r_r113 = NULL;
     }
     if (cpy_r_r113 == NULL) goto CPyL116;
-    cpy_r_r114 = CPyStatics[165]; /* 'nano' */
+    cpy_r_r114 = CPyStatics[166]; /* 'nano' */
     cpy_r_r115 = CPyDict_GetItem(cpy_r_r113, cpy_r_r114);
     CPy_DECREF(cpy_r_r113);
     if (cpy_r_r115 == NULL) goto CPyL116;
@@ -11916,7 +11931,7 @@ char CPyDef_currency___denoms_____mypyc_defaults_setup(PyObject *cpy_r___mypyc_s
     if (cpy_r_r120 == CPY_INT_TAG) goto CPyL116;
     ((faster_eth_utils___currency___denomsObject *)cpy_r___mypyc_self__)->_nano = cpy_r_r120;
     cpy_r_r121 = CPyStatic_currency___globals;
-    cpy_r_r122 = CPyStatics[154]; /* 'units' */
+    cpy_r_r122 = CPyStatics[155]; /* 'units' */
     cpy_r_r123 = CPyDict_GetItem(cpy_r_r121, cpy_r_r122);
     if (cpy_r_r123 == NULL) goto CPyL116;
     if (likely(PyDict_Check(cpy_r_r123)))
@@ -11926,7 +11941,7 @@ char CPyDef_currency___denoms_____mypyc_defaults_setup(PyObject *cpy_r___mypyc_s
         cpy_r_r124 = NULL;
     }
     if (cpy_r_r124 == NULL) goto CPyL116;
-    cpy_r_r125 = CPyStatics[166]; /* 'szabo' */
+    cpy_r_r125 = CPyStatics[167]; /* 'szabo' */
     cpy_r_r126 = CPyDict_GetItem(cpy_r_r124, cpy_r_r125);
     CPy_DECREF(cpy_r_r124);
     if (cpy_r_r126 == NULL) goto CPyL116;
@@ -11945,7 +11960,7 @@ char CPyDef_currency___denoms_____mypyc_defaults_setup(PyObject *cpy_r___mypyc_s
     if (cpy_r_r131 == CPY_INT_TAG) goto CPyL116;
     ((faster_eth_utils___currency___denomsObject *)cpy_r___mypyc_self__)->_szabo = cpy_r_r131;
     cpy_r_r132 = CPyStatic_currency___globals;
-    cpy_r_r133 = CPyStatics[154]; /* 'units' */
+    cpy_r_r133 = CPyStatics[155]; /* 'units' */
     cpy_r_r134 = CPyDict_GetItem(cpy_r_r132, cpy_r_r133);
     if (cpy_r_r134 == NULL) goto CPyL116;
     if (likely(PyDict_Check(cpy_r_r134)))
@@ -11955,7 +11970,7 @@ char CPyDef_currency___denoms_____mypyc_defaults_setup(PyObject *cpy_r___mypyc_s
         cpy_r_r135 = NULL;
     }
     if (cpy_r_r135 == NULL) goto CPyL116;
-    cpy_r_r136 = CPyStatics[167]; /* 'microether' */
+    cpy_r_r136 = CPyStatics[168]; /* 'microether' */
     cpy_r_r137 = CPyDict_GetItem(cpy_r_r135, cpy_r_r136);
     CPy_DECREF(cpy_r_r135);
     if (cpy_r_r137 == NULL) goto CPyL116;
@@ -11974,7 +11989,7 @@ char CPyDef_currency___denoms_____mypyc_defaults_setup(PyObject *cpy_r___mypyc_s
     if (cpy_r_r142 == CPY_INT_TAG) goto CPyL116;
     ((faster_eth_utils___currency___denomsObject *)cpy_r___mypyc_self__)->_microether = cpy_r_r142;
     cpy_r_r143 = CPyStatic_currency___globals;
-    cpy_r_r144 = CPyStatics[154]; /* 'units' */
+    cpy_r_r144 = CPyStatics[155]; /* 'units' */
     cpy_r_r145 = CPyDict_GetItem(cpy_r_r143, cpy_r_r144);
     if (cpy_r_r145 == NULL) goto CPyL116;
     if (likely(PyDict_Check(cpy_r_r145)))
@@ -11984,7 +11999,7 @@ char CPyDef_currency___denoms_____mypyc_defaults_setup(PyObject *cpy_r___mypyc_s
         cpy_r_r146 = NULL;
     }
     if (cpy_r_r146 == NULL) goto CPyL116;
-    cpy_r_r147 = CPyStatics[168]; /* 'micro' */
+    cpy_r_r147 = CPyStatics[169]; /* 'micro' */
     cpy_r_r148 = CPyDict_GetItem(cpy_r_r146, cpy_r_r147);
     CPy_DECREF(cpy_r_r146);
     if (cpy_r_r148 == NULL) goto CPyL116;
@@ -12003,7 +12018,7 @@ char CPyDef_currency___denoms_____mypyc_defaults_setup(PyObject *cpy_r___mypyc_s
     if (cpy_r_r153 == CPY_INT_TAG) goto CPyL116;
     ((faster_eth_utils___currency___denomsObject *)cpy_r___mypyc_self__)->_micro = cpy_r_r153;
     cpy_r_r154 = CPyStatic_currency___globals;
-    cpy_r_r155 = CPyStatics[154]; /* 'units' */
+    cpy_r_r155 = CPyStatics[155]; /* 'units' */
     cpy_r_r156 = CPyDict_GetItem(cpy_r_r154, cpy_r_r155);
     if (cpy_r_r156 == NULL) goto CPyL116;
     if (likely(PyDict_Check(cpy_r_r156)))
@@ -12013,7 +12028,7 @@ char CPyDef_currency___denoms_____mypyc_defaults_setup(PyObject *cpy_r___mypyc_s
         cpy_r_r157 = NULL;
     }
     if (cpy_r_r157 == NULL) goto CPyL116;
-    cpy_r_r158 = CPyStatics[169]; /* 'finney' */
+    cpy_r_r158 = CPyStatics[170]; /* 'finney' */
     cpy_r_r159 = CPyDict_GetItem(cpy_r_r157, cpy_r_r158);
     CPy_DECREF(cpy_r_r157);
     if (cpy_r_r159 == NULL) goto CPyL116;
@@ -12032,7 +12047,7 @@ char CPyDef_currency___denoms_____mypyc_defaults_setup(PyObject *cpy_r___mypyc_s
     if (cpy_r_r164 == CPY_INT_TAG) goto CPyL116;
     ((faster_eth_utils___currency___denomsObject *)cpy_r___mypyc_self__)->_finney = cpy_r_r164;
     cpy_r_r165 = CPyStatic_currency___globals;
-    cpy_r_r166 = CPyStatics[154]; /* 'units' */
+    cpy_r_r166 = CPyStatics[155]; /* 'units' */
     cpy_r_r167 = CPyDict_GetItem(cpy_r_r165, cpy_r_r166);
     if (cpy_r_r167 == NULL) goto CPyL116;
     if (likely(PyDict_Check(cpy_r_r167)))
@@ -12042,7 +12057,7 @@ char CPyDef_currency___denoms_____mypyc_defaults_setup(PyObject *cpy_r___mypyc_s
         cpy_r_r168 = NULL;
     }
     if (cpy_r_r168 == NULL) goto CPyL116;
-    cpy_r_r169 = CPyStatics[170]; /* 'milliether' */
+    cpy_r_r169 = CPyStatics[171]; /* 'milliether' */
     cpy_r_r170 = CPyDict_GetItem(cpy_r_r168, cpy_r_r169);
     CPy_DECREF(cpy_r_r168);
     if (cpy_r_r170 == NULL) goto CPyL116;
@@ -12061,7 +12076,7 @@ char CPyDef_currency___denoms_____mypyc_defaults_setup(PyObject *cpy_r___mypyc_s
     if (cpy_r_r175 == CPY_INT_TAG) goto CPyL116;
     ((faster_eth_utils___currency___denomsObject *)cpy_r___mypyc_self__)->_milliether = cpy_r_r175;
     cpy_r_r176 = CPyStatic_currency___globals;
-    cpy_r_r177 = CPyStatics[154]; /* 'units' */
+    cpy_r_r177 = CPyStatics[155]; /* 'units' */
     cpy_r_r178 = CPyDict_GetItem(cpy_r_r176, cpy_r_r177);
     if (cpy_r_r178 == NULL) goto CPyL116;
     if (likely(PyDict_Check(cpy_r_r178)))
@@ -12071,7 +12086,7 @@ char CPyDef_currency___denoms_____mypyc_defaults_setup(PyObject *cpy_r___mypyc_s
         cpy_r_r179 = NULL;
     }
     if (cpy_r_r179 == NULL) goto CPyL116;
-    cpy_r_r180 = CPyStatics[171]; /* 'milli' */
+    cpy_r_r180 = CPyStatics[172]; /* 'milli' */
     cpy_r_r181 = CPyDict_GetItem(cpy_r_r179, cpy_r_r180);
     CPy_DECREF(cpy_r_r179);
     if (cpy_r_r181 == NULL) goto CPyL116;
@@ -12090,7 +12105,7 @@ char CPyDef_currency___denoms_____mypyc_defaults_setup(PyObject *cpy_r___mypyc_s
     if (cpy_r_r186 == CPY_INT_TAG) goto CPyL116;
     ((faster_eth_utils___currency___denomsObject *)cpy_r___mypyc_self__)->_milli = cpy_r_r186;
     cpy_r_r187 = CPyStatic_currency___globals;
-    cpy_r_r188 = CPyStatics[154]; /* 'units' */
+    cpy_r_r188 = CPyStatics[155]; /* 'units' */
     cpy_r_r189 = CPyDict_GetItem(cpy_r_r187, cpy_r_r188);
     if (cpy_r_r189 == NULL) goto CPyL116;
     if (likely(PyDict_Check(cpy_r_r189)))
@@ -12100,7 +12115,7 @@ char CPyDef_currency___denoms_____mypyc_defaults_setup(PyObject *cpy_r___mypyc_s
         cpy_r_r190 = NULL;
     }
     if (cpy_r_r190 == NULL) goto CPyL116;
-    cpy_r_r191 = CPyStatics[172]; /* 'ether' */
+    cpy_r_r191 = CPyStatics[173]; /* 'ether' */
     cpy_r_r192 = CPyDict_GetItem(cpy_r_r190, cpy_r_r191);
     CPy_DECREF(cpy_r_r190);
     if (cpy_r_r192 == NULL) goto CPyL116;
@@ -12119,7 +12134,7 @@ char CPyDef_currency___denoms_____mypyc_defaults_setup(PyObject *cpy_r___mypyc_s
     if (cpy_r_r197 == CPY_INT_TAG) goto CPyL116;
     ((faster_eth_utils___currency___denomsObject *)cpy_r___mypyc_self__)->_ether = cpy_r_r197;
     cpy_r_r198 = CPyStatic_currency___globals;
-    cpy_r_r199 = CPyStatics[154]; /* 'units' */
+    cpy_r_r199 = CPyStatics[155]; /* 'units' */
     cpy_r_r200 = CPyDict_GetItem(cpy_r_r198, cpy_r_r199);
     if (cpy_r_r200 == NULL) goto CPyL116;
     if (likely(PyDict_Check(cpy_r_r200)))
@@ -12129,7 +12144,7 @@ char CPyDef_currency___denoms_____mypyc_defaults_setup(PyObject *cpy_r___mypyc_s
         cpy_r_r201 = NULL;
     }
     if (cpy_r_r201 == NULL) goto CPyL116;
-    cpy_r_r202 = CPyStatics[173]; /* 'kether' */
+    cpy_r_r202 = CPyStatics[174]; /* 'kether' */
     cpy_r_r203 = CPyDict_GetItem(cpy_r_r201, cpy_r_r202);
     CPy_DECREF(cpy_r_r201);
     if (cpy_r_r203 == NULL) goto CPyL116;
@@ -12148,7 +12163,7 @@ char CPyDef_currency___denoms_____mypyc_defaults_setup(PyObject *cpy_r___mypyc_s
     if (cpy_r_r208 == CPY_INT_TAG) goto CPyL116;
     ((faster_eth_utils___currency___denomsObject *)cpy_r___mypyc_self__)->_kether = cpy_r_r208;
     cpy_r_r209 = CPyStatic_currency___globals;
-    cpy_r_r210 = CPyStatics[154]; /* 'units' */
+    cpy_r_r210 = CPyStatics[155]; /* 'units' */
     cpy_r_r211 = CPyDict_GetItem(cpy_r_r209, cpy_r_r210);
     if (cpy_r_r211 == NULL) goto CPyL116;
     if (likely(PyDict_Check(cpy_r_r211)))
@@ -12158,7 +12173,7 @@ char CPyDef_currency___denoms_____mypyc_defaults_setup(PyObject *cpy_r___mypyc_s
         cpy_r_r212 = NULL;
     }
     if (cpy_r_r212 == NULL) goto CPyL116;
-    cpy_r_r213 = CPyStatics[174]; /* 'grand' */
+    cpy_r_r213 = CPyStatics[175]; /* 'grand' */
     cpy_r_r214 = CPyDict_GetItem(cpy_r_r212, cpy_r_r213);
     CPy_DECREF(cpy_r_r212);
     if (cpy_r_r214 == NULL) goto CPyL116;
@@ -12177,7 +12192,7 @@ char CPyDef_currency___denoms_____mypyc_defaults_setup(PyObject *cpy_r___mypyc_s
     if (cpy_r_r219 == CPY_INT_TAG) goto CPyL116;
     ((faster_eth_utils___currency___denomsObject *)cpy_r___mypyc_self__)->_grand = cpy_r_r219;
     cpy_r_r220 = CPyStatic_currency___globals;
-    cpy_r_r221 = CPyStatics[154]; /* 'units' */
+    cpy_r_r221 = CPyStatics[155]; /* 'units' */
     cpy_r_r222 = CPyDict_GetItem(cpy_r_r220, cpy_r_r221);
     if (cpy_r_r222 == NULL) goto CPyL116;
     if (likely(PyDict_Check(cpy_r_r222)))
@@ -12187,7 +12202,7 @@ char CPyDef_currency___denoms_____mypyc_defaults_setup(PyObject *cpy_r___mypyc_s
         cpy_r_r223 = NULL;
     }
     if (cpy_r_r223 == NULL) goto CPyL116;
-    cpy_r_r224 = CPyStatics[175]; /* 'mether' */
+    cpy_r_r224 = CPyStatics[176]; /* 'mether' */
     cpy_r_r225 = CPyDict_GetItem(cpy_r_r223, cpy_r_r224);
     CPy_DECREF(cpy_r_r223);
     if (cpy_r_r225 == NULL) goto CPyL116;
@@ -12206,7 +12221,7 @@ char CPyDef_currency___denoms_____mypyc_defaults_setup(PyObject *cpy_r___mypyc_s
     if (cpy_r_r230 == CPY_INT_TAG) goto CPyL116;
     ((faster_eth_utils___currency___denomsObject *)cpy_r___mypyc_self__)->_mether = cpy_r_r230;
     cpy_r_r231 = CPyStatic_currency___globals;
-    cpy_r_r232 = CPyStatics[154]; /* 'units' */
+    cpy_r_r232 = CPyStatics[155]; /* 'units' */
     cpy_r_r233 = CPyDict_GetItem(cpy_r_r231, cpy_r_r232);
     if (cpy_r_r233 == NULL) goto CPyL116;
     if (likely(PyDict_Check(cpy_r_r233)))
@@ -12216,7 +12231,7 @@ char CPyDef_currency___denoms_____mypyc_defaults_setup(PyObject *cpy_r___mypyc_s
         cpy_r_r234 = NULL;
     }
     if (cpy_r_r234 == NULL) goto CPyL116;
-    cpy_r_r235 = CPyStatics[176]; /* 'gether' */
+    cpy_r_r235 = CPyStatics[177]; /* 'gether' */
     cpy_r_r236 = CPyDict_GetItem(cpy_r_r234, cpy_r_r235);
     CPy_DECREF(cpy_r_r234);
     if (cpy_r_r236 == NULL) goto CPyL116;
@@ -12235,7 +12250,7 @@ char CPyDef_currency___denoms_____mypyc_defaults_setup(PyObject *cpy_r___mypyc_s
     if (cpy_r_r241 == CPY_INT_TAG) goto CPyL116;
     ((faster_eth_utils___currency___denomsObject *)cpy_r___mypyc_self__)->_gether = cpy_r_r241;
     cpy_r_r242 = CPyStatic_currency___globals;
-    cpy_r_r243 = CPyStatics[154]; /* 'units' */
+    cpy_r_r243 = CPyStatics[155]; /* 'units' */
     cpy_r_r244 = CPyDict_GetItem(cpy_r_r242, cpy_r_r243);
     if (cpy_r_r244 == NULL) goto CPyL116;
     if (likely(PyDict_Check(cpy_r_r244)))
@@ -12245,7 +12260,7 @@ char CPyDef_currency___denoms_____mypyc_defaults_setup(PyObject *cpy_r___mypyc_s
         cpy_r_r245 = NULL;
     }
     if (cpy_r_r245 == NULL) goto CPyL116;
-    cpy_r_r246 = CPyStatics[177]; /* 'tether' */
+    cpy_r_r246 = CPyStatics[178]; /* 'tether' */
     cpy_r_r247 = CPyDict_GetItem(cpy_r_r245, cpy_r_r246);
     CPy_DECREF(cpy_r_r245);
     if (cpy_r_r247 == NULL) goto CPyL116;
@@ -12440,7 +12455,7 @@ PyObject *CPyDef_currency____from_wei(CPyTagged cpy_r_number, PyObject *cpy_r_un
     } else
         goto CPyL2;
 CPyL1: ;
-    cpy_r_r2 = CPyStatics[322]; /* 0 */
+    cpy_r_r2 = CPyStatics[323]; /* 0 */
     return cpy_r_r2;
 CPyL2: ;
     cpy_r_r3 = cpy_r_number & 1;
@@ -12459,7 +12474,7 @@ CPyL5: ;
     cpy_r_r8 = (Py_ssize_t)cpy_r_number < (Py_ssize_t)0;
     if (cpy_r_r8) goto CPyL51;
 CPyL6: ;
-    cpy_r_r9 = (CPyTagged)CPyStatics[323] | 1; /* 115792089237316195423570985008687907853269984665640564039457584007913129639935 */
+    cpy_r_r9 = (CPyTagged)CPyStatics[324] | 1; /* 115792089237316195423570985008687907853269984665640564039457584007913129639935 */
     cpy_r_r10 = cpy_r_number & 1;
     cpy_r_r11 = cpy_r_r10 != 0;
     if (cpy_r_r11) goto CPyL8;
@@ -12479,7 +12494,7 @@ CPyL9: ;
     } else
         goto CPyL14;
 CPyL10: ;
-    cpy_r_r16 = CPyStatics[178]; /* 'value must be between 0 and 2**256 - 1' */
+    cpy_r_r16 = CPyStatics[179]; /* 'value must be between 0 and 2**256 - 1' */
     cpy_r_r17 = CPyModule_builtins;
     cpy_r_r18 = CPyStatics[25]; /* 'ValueError' */
     cpy_r_r19 = CPyObject_GetAttr(cpy_r_r17, cpy_r_r18);
@@ -12504,7 +12519,7 @@ CPyL10: ;
     CPy_Unreachable();
 CPyL14: ;
     cpy_r_r23 = CPyStatic_currency___globals;
-    cpy_r_r24 = CPyStatics[179]; /* 'localcontext' */
+    cpy_r_r24 = CPyStatics[180]; /* 'localcontext' */
     cpy_r_r25 = CPyDict_GetItem(cpy_r_r23, cpy_r_r24);
     if (unlikely(cpy_r_r25 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/currency.py", "_from_wei", 60, CPyStatic_currency___globals);
@@ -12517,13 +12532,13 @@ CPyL14: ;
         goto CPyL52;
     }
     cpy_r_r27 = PyObject_Type(cpy_r_r26);
-    cpy_r_r28 = CPyStatics[180]; /* '__exit__' */
+    cpy_r_r28 = CPyStatics[181]; /* '__exit__' */
     cpy_r_r29 = CPyObject_GetAttr(cpy_r_r27, cpy_r_r28);
     if (unlikely(cpy_r_r29 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/currency.py", "_from_wei", 60, CPyStatic_currency___globals);
         goto CPyL53;
     }
-    cpy_r_r30 = CPyStatics[181]; /* '__enter__' */
+    cpy_r_r30 = CPyStatics[182]; /* '__enter__' */
     cpy_r_r31 = CPyObject_GetAttr(cpy_r_r27, cpy_r_r30);
     CPy_DECREF(cpy_r_r27);
     if (unlikely(cpy_r_r31 == NULL)) {
@@ -12539,8 +12554,8 @@ CPyL14: ;
         goto CPyL54;
     }
     cpy_r_r35 = 1;
-    cpy_r_r36 = CPyStatics[182]; /* 'prec' */
-    cpy_r_r37 = CPyStatics[324]; /* 999 */
+    cpy_r_r36 = CPyStatics[183]; /* 'prec' */
+    cpy_r_r37 = CPyStatics[325]; /* 999 */
     cpy_r_r38 = PyObject_SetAttr(cpy_r_r34, cpy_r_r36, cpy_r_r37);
     cpy_r_r39 = cpy_r_r38 >= 0;
     if (unlikely(!cpy_r_r39)) {
@@ -12548,7 +12563,7 @@ CPyL14: ;
         goto CPyL55;
     }
     cpy_r_r40 = CPyModule_decimal;
-    cpy_r_r41 = CPyStatics[183]; /* 'Decimal' */
+    cpy_r_r41 = CPyStatics[184]; /* 'Decimal' */
     cpy_r_r42 = CPyObject_GetAttr(cpy_r_r40, cpy_r_r41);
     if (unlikely(cpy_r_r42 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/currency.py", "_from_wei", 62, CPyStatic_currency___globals);
@@ -12558,7 +12573,7 @@ CPyL14: ;
     cpy_r_r43 = CPyTagged_StealAsObject(cpy_r_number);
     PyObject *cpy_r_r44[2] = {cpy_r_r43, cpy_r_r34};
     cpy_r_r45 = (PyObject **)&cpy_r_r44;
-    cpy_r_r46 = CPyStatics[358]; /* ('value', 'context') */
+    cpy_r_r46 = CPyStatics[360]; /* ('value', 'context') */
     cpy_r_r47 = PyObject_Vectorcall(cpy_r_r42, cpy_r_r45, 0, cpy_r_r46);
     CPy_DECREF(cpy_r_r42);
     if (unlikely(cpy_r_r47 == NULL)) {
@@ -12980,7 +12995,7 @@ CPyTagged CPyDef_currency____to_wei(PyObject *cpy_r_number, PyObject *cpy_r_unit
     if (!cpy_r_r3) goto CPyL7;
 CPyL4: ;
     cpy_r_r4 = CPyModule_decimal;
-    cpy_r_r5 = CPyStatics[183]; /* 'Decimal' */
+    cpy_r_r5 = CPyStatics[184]; /* 'Decimal' */
     cpy_r_r6 = CPyObject_GetAttr(cpy_r_r4, cpy_r_r5);
     if (unlikely(cpy_r_r6 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/currency.py", "_to_wei", 70, CPyStatic_currency___globals);
@@ -12988,7 +13003,7 @@ CPyL4: ;
     }
     PyObject *cpy_r_r7[1] = {cpy_r_number};
     cpy_r_r8 = (PyObject **)&cpy_r_r7;
-    cpy_r_r9 = CPyStatics[359]; /* ('value',) */
+    cpy_r_r9 = CPyStatics[361]; /* ('value',) */
     cpy_r_r10 = PyObject_Vectorcall(cpy_r_r6, cpy_r_r8, 0, cpy_r_r9);
     CPy_DECREF(cpy_r_r6);
     if (unlikely(cpy_r_r10 == NULL)) {
@@ -13031,7 +13046,7 @@ CPyL11: ;
         goto CPyL10;
 CPyL12: ;
     cpy_r_r20 = CPyModule_decimal;
-    cpy_r_r21 = CPyStatics[183]; /* 'Decimal' */
+    cpy_r_r21 = CPyStatics[184]; /* 'Decimal' */
     cpy_r_r22 = CPyObject_GetAttr(cpy_r_r20, cpy_r_r21);
     if (unlikely(cpy_r_r22 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/currency.py", "_to_wei", 72, CPyStatic_currency___globals);
@@ -13039,7 +13054,7 @@ CPyL12: ;
     }
     PyObject *cpy_r_r23[1] = {cpy_r_r18};
     cpy_r_r24 = (PyObject **)&cpy_r_r23;
-    cpy_r_r25 = CPyStatics[359]; /* ('value',) */
+    cpy_r_r25 = CPyStatics[361]; /* ('value',) */
     cpy_r_r26 = PyObject_Vectorcall(cpy_r_r22, cpy_r_r24, 0, cpy_r_r25);
     CPy_DECREF(cpy_r_r22);
     if (unlikely(cpy_r_r26 == NULL)) {
@@ -13051,7 +13066,7 @@ CPyL12: ;
     goto CPyL23;
 CPyL15: ;
     cpy_r_r27 = CPyModule_decimal;
-    cpy_r_r28 = CPyStatics[183]; /* 'Decimal' */
+    cpy_r_r28 = CPyStatics[184]; /* 'Decimal' */
     cpy_r_r29 = CPyObject_GetAttr(cpy_r_r27, cpy_r_r28);
     if (unlikely(cpy_r_r29 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/currency.py", "_to_wei", 73, CPyStatic_currency___globals);
@@ -13070,7 +13085,7 @@ CPyL15: ;
     cpy_r_d_number = cpy_r_number;
     goto CPyL23;
 CPyL19: ;
-    cpy_r_r33 = CPyStatics[186]; /* ('Unsupported type. Must be one of integer, float, or '
+    cpy_r_r33 = CPyStatics[187]; /* ('Unsupported type. Must be one of integer, float, or '
                                     'string') */
     cpy_r_r34 = CPyModule_builtins;
     cpy_r_r35 = CPyStatics[16]; /* 'TypeError' */
@@ -13096,13 +13111,13 @@ CPyL19: ;
     CPy_Unreachable();
 CPyL23: ;
     cpy_r_r40 = CPyModule_decimal;
-    cpy_r_r41 = CPyStatics[183]; /* 'Decimal' */
+    cpy_r_r41 = CPyStatics[184]; /* 'Decimal' */
     cpy_r_r42 = CPyObject_GetAttr(cpy_r_r40, cpy_r_r41);
     if (unlikely(cpy_r_r42 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/currency.py", "_to_wei", 78, CPyStatic_currency___globals);
         goto CPyL136;
     }
-    cpy_r_r43 = CPyStatics[322]; /* 0 */
+    cpy_r_r43 = CPyStatics[323]; /* 0 */
     PyObject *cpy_r_r44[1] = {cpy_r_r43};
     cpy_r_r45 = (PyObject **)&cpy_r_r44;
     cpy_r_r46 = PyObject_Vectorcall(cpy_r_r42, cpy_r_r45, 1, 0);
@@ -13138,7 +13153,7 @@ CPyL29: ;
         CPy_AddTraceback("faster_eth_utils/currency.py", "_to_wei", 81, CPyStatic_currency___globals);
         goto CPyL136;
     }
-    cpy_r_r50 = CPyStatics[319]; /* 1 */
+    cpy_r_r50 = CPyStatics[320]; /* 1 */
     cpy_r_r51 = PyObject_RichCompare(cpy_r_d_number, cpy_r_r50, 0);
     if (unlikely(cpy_r_r51 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/currency.py", "_to_wei", 83, CPyStatic_currency___globals);
@@ -13154,7 +13169,7 @@ CPyL29: ;
         goto CPyL138;
     }
     if (!cpy_r_r52) goto CPyL139;
-    cpy_r_r53 = CPyStatics[187]; /* '.' */
+    cpy_r_r53 = CPyStatics[188]; /* '.' */
     cpy_r_r54 = PyUnicode_Contains(cpy_r_r49, cpy_r_r53);
     cpy_r_r55 = cpy_r_r54 >= 0;
     if (unlikely(!cpy_r_r55)) {
@@ -13164,7 +13179,7 @@ CPyL29: ;
     cpy_r_r56 = cpy_r_r54;
     if (!cpy_r_r56) goto CPyL139;
     cpy_r_r57 = CPyStatic_currency___globals;
-    cpy_r_r58 = CPyStatics[179]; /* 'localcontext' */
+    cpy_r_r58 = CPyStatics[180]; /* 'localcontext' */
     cpy_r_r59 = CPyDict_GetItem(cpy_r_r57, cpy_r_r58);
     if (unlikely(cpy_r_r59 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/currency.py", "_to_wei", 84, CPyStatic_currency___globals);
@@ -13177,13 +13192,13 @@ CPyL29: ;
         goto CPyL138;
     }
     cpy_r_r61 = PyObject_Type(cpy_r_r60);
-    cpy_r_r62 = CPyStatics[180]; /* '__exit__' */
+    cpy_r_r62 = CPyStatics[181]; /* '__exit__' */
     cpy_r_r63 = CPyObject_GetAttr(cpy_r_r61, cpy_r_r62);
     if (unlikely(cpy_r_r63 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/currency.py", "_to_wei", 84, CPyStatic_currency___globals);
         goto CPyL140;
     }
-    cpy_r_r64 = CPyStatics[181]; /* '__enter__' */
+    cpy_r_r64 = CPyStatics[182]; /* '__enter__' */
     cpy_r_r65 = CPyObject_GetAttr(cpy_r_r61, cpy_r_r64);
     CPy_DECREF(cpy_r_r61);
     if (unlikely(cpy_r_r65 == NULL)) {
@@ -13206,7 +13221,7 @@ CPyL29: ;
         goto CPyL142;
     }
     cpy_r_r72 = cpy_r_r70 << 1;
-    cpy_r_r73 = CPyStatics[187]; /* '.' */
+    cpy_r_r73 = CPyStatics[188]; /* '.' */
     cpy_r_r74 = CPyStatics[46]; /* 'index' */
     PyObject *cpy_r_r75[2] = {cpy_r_r49, cpy_r_r73};
     cpy_r_r76 = (PyObject **)&cpy_r_r75;
@@ -13233,7 +13248,7 @@ CPyL44: ;
     cpy_r_r80 = CPyTagged_Subtract(cpy_r_r79, 2);
     CPyTagged_DECREF(cpy_r_r79);
     cpy_r_multiplier = cpy_r_r80;
-    cpy_r_r81 = CPyStatics[182]; /* 'prec' */
+    cpy_r_r81 = CPyStatics[183]; /* 'prec' */
     CPyTagged_INCREF(cpy_r_multiplier);
     cpy_r_r82 = CPyTagged_StealAsObject(cpy_r_multiplier);
     cpy_r_r83 = PyObject_SetAttr(cpy_r_r68, cpy_r_r81, cpy_r_r82);
@@ -13244,7 +13259,7 @@ CPyL44: ;
         goto CPyL143;
     }
     cpy_r_r85 = CPyModule_decimal;
-    cpy_r_r86 = CPyStatics[183]; /* 'Decimal' */
+    cpy_r_r86 = CPyStatics[184]; /* 'Decimal' */
     cpy_r_r87 = CPyObject_GetAttr(cpy_r_r85, cpy_r_r86);
     if (unlikely(cpy_r_r87 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/currency.py", "_to_wei", 87, CPyStatic_currency___globals);
@@ -13252,7 +13267,7 @@ CPyL44: ;
     }
     PyObject *cpy_r_r88[2] = {cpy_r_number, cpy_r_r68};
     cpy_r_r89 = (PyObject **)&cpy_r_r88;
-    cpy_r_r90 = CPyStatics[358]; /* ('value', 'context') */
+    cpy_r_r90 = CPyStatics[360]; /* ('value', 'context') */
     cpy_r_r91 = PyObject_Vectorcall(cpy_r_r87, cpy_r_r89, 0, cpy_r_r90);
     CPy_DECREF(cpy_r_r87);
     if (unlikely(cpy_r_r91 == NULL)) {
@@ -13260,7 +13275,7 @@ CPyL44: ;
         goto CPyL143;
     }
     CPy_DECREF(cpy_r_r68);
-    cpy_r_r92 = CPyStatics[325]; /* 10 */
+    cpy_r_r92 = CPyStatics[326]; /* 10 */
     CPyTagged_INCREF(cpy_r_multiplier);
     cpy_r_r93 = CPyTagged_StealAsObject(cpy_r_multiplier);
     cpy_r_r94 = CPyNumber_Power(cpy_r_r92, cpy_r_r93);
@@ -13383,7 +13398,7 @@ CPyL68: ;
     if (!cpy_r_r115) goto CPyL132;
     CPy_Unreachable();
 CPyL70: ;
-    cpy_r_r116 = CPyStatics[325]; /* 10 */
+    cpy_r_r116 = CPyStatics[326]; /* 10 */
     if (cpy_r_multiplier == CPY_INT_TAG) {
         goto CPyL155;
     } else
@@ -13413,7 +13428,7 @@ CPyL73: ;
     cpy_r_unit_value = cpy_r_r120;
 CPyL76: ;
     cpy_r_r121 = CPyStatic_currency___globals;
-    cpy_r_r122 = CPyStatics[179]; /* 'localcontext' */
+    cpy_r_r122 = CPyStatics[180]; /* 'localcontext' */
     cpy_r_r123 = CPyDict_GetItem(cpy_r_r121, cpy_r_r122);
     if (unlikely(cpy_r_r123 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/currency.py", "_to_wei", 90, CPyStatic_currency___globals);
@@ -13426,13 +13441,13 @@ CPyL76: ;
         goto CPyL157;
     }
     cpy_r_r125 = PyObject_Type(cpy_r_r124);
-    cpy_r_r126 = CPyStatics[180]; /* '__exit__' */
+    cpy_r_r126 = CPyStatics[181]; /* '__exit__' */
     cpy_r_r127 = CPyObject_GetAttr(cpy_r_r125, cpy_r_r126);
     if (unlikely(cpy_r_r127 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/currency.py", "_to_wei", 90, CPyStatic_currency___globals);
         goto CPyL158;
     }
-    cpy_r_r128 = CPyStatics[181]; /* '__enter__' */
+    cpy_r_r128 = CPyStatics[182]; /* '__enter__' */
     cpy_r_r129 = CPyObject_GetAttr(cpy_r_r125, cpy_r_r128);
     CPy_DECREF(cpy_r_r125);
     if (unlikely(cpy_r_r129 == NULL)) {
@@ -13448,8 +13463,8 @@ CPyL76: ;
         goto CPyL159;
     }
     cpy_r_r133 = 1;
-    cpy_r_r134 = CPyStatics[182]; /* 'prec' */
-    cpy_r_r135 = CPyStatics[324]; /* 999 */
+    cpy_r_r134 = CPyStatics[183]; /* 'prec' */
+    cpy_r_r135 = CPyStatics[325]; /* 999 */
     cpy_r_r136 = PyObject_SetAttr(cpy_r_r132, cpy_r_r134, cpy_r_r135);
     cpy_r_r137 = cpy_r_r136 >= 0;
     if (unlikely(!cpy_r_r137)) {
@@ -13457,7 +13472,7 @@ CPyL76: ;
         goto CPyL160;
     }
     cpy_r_r138 = CPyModule_decimal;
-    cpy_r_r139 = CPyStatics[183]; /* 'Decimal' */
+    cpy_r_r139 = CPyStatics[184]; /* 'Decimal' */
     cpy_r_r140 = CPyObject_GetAttr(cpy_r_r138, cpy_r_r139);
     if (unlikely(cpy_r_r140 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/currency.py", "_to_wei", 92, CPyStatic_currency___globals);
@@ -13465,7 +13480,7 @@ CPyL76: ;
     }
     PyObject *cpy_r_r141[2] = {cpy_r_d_number, cpy_r_r132};
     cpy_r_r142 = (PyObject **)&cpy_r_r141;
-    cpy_r_r143 = CPyStatics[358]; /* ('value', 'context') */
+    cpy_r_r143 = CPyStatics[360]; /* ('value', 'context') */
     cpy_r_r144 = PyObject_Vectorcall(cpy_r_r140, cpy_r_r142, 0, cpy_r_r143);
     CPy_DECREF(cpy_r_r140);
     if (unlikely(cpy_r_r144 == NULL)) {
@@ -13588,7 +13603,7 @@ CPyL105: ;
     if (!cpy_r_r165) goto CPyL132;
     CPy_Unreachable();
 CPyL107: ;
-    cpy_r_r166 = CPyStatics[322]; /* 0 */
+    cpy_r_r166 = CPyStatics[323]; /* 0 */
     if (cpy_r_result_value != NULL) goto CPyL110;
     PyErr_SetString(PyExc_UnboundLocalError, "local variable \"result_value\" referenced before assignment");
     cpy_r_r167 = 0;
@@ -13613,7 +13628,7 @@ CPyL110: ;
         goto CPyL170;
     }
     if (cpy_r_r169) goto CPyL171;
-    cpy_r_r170 = (CPyTagged)CPyStatics[323] | 1; /* 115792089237316195423570985008687907853269984665640564039457584007913129639935 */
+    cpy_r_r170 = (CPyTagged)CPyStatics[324] | 1; /* 115792089237316195423570985008687907853269984665640564039457584007913129639935 */
     CPyTagged_INCREF(cpy_r_r170);
     cpy_r_r171 = CPyTagged_StealAsObject(cpy_r_r170);
     if (cpy_r_result_value == NULL) {
@@ -13649,7 +13664,7 @@ CPyL116: ;
     } else
         goto CPyL123;
 CPyL119: ;
-    cpy_r_r175 = CPyStatics[188]; /* 'Resulting wei value must be between 0 and 2**256 - 1' */
+    cpy_r_r175 = CPyStatics[189]; /* 'Resulting wei value must be between 0 and 2**256 - 1' */
     cpy_r_r176 = CPyModule_builtins;
     cpy_r_r177 = CPyStatics[25]; /* 'ValueError' */
     cpy_r_r178 = CPyObject_GetAttr(cpy_r_r176, cpy_r_r177);
@@ -14012,7 +14027,7 @@ PyObject *CPyDef_currency___from_wei(CPyTagged cpy_r_number, PyObject *cpy_r_uni
         goto CPyL22;
     }
     cpy_r_r5 = CPyStatic_currency___globals;
-    cpy_r_r6 = CPyStatics[154]; /* 'units' */
+    cpy_r_r6 = CPyStatics[155]; /* 'units' */
     cpy_r_r7 = CPyDict_GetItem(cpy_r_r5, cpy_r_r6);
     if (unlikely(cpy_r_r7 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/currency.py", "from_wei", 104, CPyStatic_currency___globals);
@@ -14035,10 +14050,10 @@ PyObject *CPyDef_currency___from_wei(CPyTagged cpy_r_number, PyObject *cpy_r_uni
     cpy_r_r11 = cpy_r_r9;
     cpy_r_r12 = cpy_r_r11 ^ 1;
     if (!cpy_r_r12) goto CPyL15;
-    cpy_r_r13 = CPyStatics[189]; /* 'Unknown unit. Must be one of ' */
-    cpy_r_r14 = CPyStatics[190]; /* '/' */
+    cpy_r_r13 = CPyStatics[190]; /* 'Unknown unit. Must be one of ' */
+    cpy_r_r14 = CPyStatics[191]; /* '/' */
     cpy_r_r15 = CPyStatic_currency___globals;
-    cpy_r_r16 = CPyStatics[154]; /* 'units' */
+    cpy_r_r16 = CPyStatics[155]; /* 'units' */
     cpy_r_r17 = CPyDict_GetItem(cpy_r_r15, cpy_r_r16);
     if (unlikely(cpy_r_r17 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/currency.py", "from_wei", 105, CPyStatic_currency___globals);
@@ -14093,7 +14108,7 @@ PyObject *CPyDef_currency___from_wei(CPyTagged cpy_r_number, PyObject *cpy_r_uni
     CPy_Unreachable();
 CPyL15: ;
     cpy_r_r28 = CPyStatic_currency___globals;
-    cpy_r_r29 = CPyStatics[154]; /* 'units' */
+    cpy_r_r29 = CPyStatics[155]; /* 'units' */
     cpy_r_r30 = CPyDict_GetItem(cpy_r_r28, cpy_r_r29);
     if (unlikely(cpy_r_r30 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/currency.py", "from_wei", 107, CPyStatic_currency___globals);
@@ -14228,7 +14243,7 @@ CPyTagged CPyDef_currency___to_wei(PyObject *cpy_r_number, PyObject *cpy_r_unit)
         goto CPyL22;
     }
     cpy_r_r5 = CPyStatic_currency___globals;
-    cpy_r_r6 = CPyStatics[154]; /* 'units' */
+    cpy_r_r6 = CPyStatics[155]; /* 'units' */
     cpy_r_r7 = CPyDict_GetItem(cpy_r_r5, cpy_r_r6);
     if (unlikely(cpy_r_r7 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/currency.py", "to_wei", 116, CPyStatic_currency___globals);
@@ -14251,10 +14266,10 @@ CPyTagged CPyDef_currency___to_wei(PyObject *cpy_r_number, PyObject *cpy_r_unit)
     cpy_r_r11 = cpy_r_r9;
     cpy_r_r12 = cpy_r_r11 ^ 1;
     if (!cpy_r_r12) goto CPyL15;
-    cpy_r_r13 = CPyStatics[189]; /* 'Unknown unit. Must be one of ' */
-    cpy_r_r14 = CPyStatics[190]; /* '/' */
+    cpy_r_r13 = CPyStatics[190]; /* 'Unknown unit. Must be one of ' */
+    cpy_r_r14 = CPyStatics[191]; /* '/' */
     cpy_r_r15 = CPyStatic_currency___globals;
-    cpy_r_r16 = CPyStatics[154]; /* 'units' */
+    cpy_r_r16 = CPyStatics[155]; /* 'units' */
     cpy_r_r17 = CPyDict_GetItem(cpy_r_r15, cpy_r_r16);
     if (unlikely(cpy_r_r17 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/currency.py", "to_wei", 117, CPyStatic_currency___globals);
@@ -14309,7 +14324,7 @@ CPyTagged CPyDef_currency___to_wei(PyObject *cpy_r_number, PyObject *cpy_r_unit)
     CPy_Unreachable();
 CPyL15: ;
     cpy_r_r28 = CPyStatic_currency___globals;
-    cpy_r_r29 = CPyStatics[154]; /* 'units' */
+    cpy_r_r29 = CPyStatics[155]; /* 'units' */
     cpy_r_r30 = CPyDict_GetItem(cpy_r_r28, cpy_r_r29);
     if (unlikely(cpy_r_r30 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/currency.py", "to_wei", 119, CPyStatic_currency___globals);
@@ -14431,13 +14446,13 @@ PyObject *CPyDef_currency___from_wei_decimals(CPyTagged cpy_r_number, CPyTagged 
     PyObject *cpy_r_r16;
     PyObject *cpy_r_r17;
     cpy_r_r0 = CPyModule_decimal;
-    cpy_r_r1 = CPyStatics[183]; /* 'Decimal' */
+    cpy_r_r1 = CPyStatics[184]; /* 'Decimal' */
     cpy_r_r2 = CPyObject_GetAttr(cpy_r_r0, cpy_r_r1);
     if (unlikely(cpy_r_r2 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/currency.py", "from_wei_decimals", 129, CPyStatic_currency___globals);
         goto CPyL7;
     }
-    cpy_r_r3 = CPyStatics[325]; /* 10 */
+    cpy_r_r3 = CPyStatics[326]; /* 10 */
     PyObject *cpy_r_r4[1] = {cpy_r_r3};
     cpy_r_r5 = (PyObject **)&cpy_r_r4;
     cpy_r_r6 = PyObject_Vectorcall(cpy_r_r2, cpy_r_r5, 1, 0);
@@ -14447,7 +14462,7 @@ PyObject *CPyDef_currency___from_wei_decimals(CPyTagged cpy_r_number, CPyTagged 
         goto CPyL7;
     }
     cpy_r_r7 = CPyModule_decimal;
-    cpy_r_r8 = CPyStatics[183]; /* 'Decimal' */
+    cpy_r_r8 = CPyStatics[184]; /* 'Decimal' */
     cpy_r_r9 = CPyObject_GetAttr(cpy_r_r7, cpy_r_r8);
     if (unlikely(cpy_r_r9 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/currency.py", "from_wei_decimals", 129, CPyStatic_currency___globals);
@@ -14457,7 +14472,7 @@ PyObject *CPyDef_currency___from_wei_decimals(CPyTagged cpy_r_number, CPyTagged 
     cpy_r_r10 = CPyTagged_StealAsObject(cpy_r_decimals);
     PyObject *cpy_r_r11[1] = {cpy_r_r10};
     cpy_r_r12 = (PyObject **)&cpy_r_r11;
-    cpy_r_r13 = CPyStatics[359]; /* ('value',) */
+    cpy_r_r13 = CPyStatics[361]; /* ('value',) */
     cpy_r_r14 = PyObject_Vectorcall(cpy_r_r9, cpy_r_r12, 0, cpy_r_r13);
     CPy_DECREF(cpy_r_r9);
     if (unlikely(cpy_r_r14 == NULL)) {
@@ -14536,13 +14551,13 @@ CPyTagged CPyDef_currency___to_wei_decimals(PyObject *cpy_r_number, CPyTagged cp
     CPyTagged cpy_r_r16;
     CPyTagged cpy_r_r17;
     cpy_r_r0 = CPyModule_decimal;
-    cpy_r_r1 = CPyStatics[183]; /* 'Decimal' */
+    cpy_r_r1 = CPyStatics[184]; /* 'Decimal' */
     cpy_r_r2 = CPyObject_GetAttr(cpy_r_r0, cpy_r_r1);
     if (unlikely(cpy_r_r2 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/currency.py", "to_wei_decimals", 139, CPyStatic_currency___globals);
         goto CPyL7;
     }
-    cpy_r_r3 = CPyStatics[325]; /* 10 */
+    cpy_r_r3 = CPyStatics[326]; /* 10 */
     PyObject *cpy_r_r4[1] = {cpy_r_r3};
     cpy_r_r5 = (PyObject **)&cpy_r_r4;
     cpy_r_r6 = PyObject_Vectorcall(cpy_r_r2, cpy_r_r5, 1, 0);
@@ -14552,7 +14567,7 @@ CPyTagged CPyDef_currency___to_wei_decimals(PyObject *cpy_r_number, CPyTagged cp
         goto CPyL7;
     }
     cpy_r_r7 = CPyModule_decimal;
-    cpy_r_r8 = CPyStatics[183]; /* 'Decimal' */
+    cpy_r_r8 = CPyStatics[184]; /* 'Decimal' */
     cpy_r_r9 = CPyObject_GetAttr(cpy_r_r7, cpy_r_r8);
     if (unlikely(cpy_r_r9 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/currency.py", "to_wei_decimals", 139, CPyStatic_currency___globals);
@@ -14562,7 +14577,7 @@ CPyTagged CPyDef_currency___to_wei_decimals(PyObject *cpy_r_number, CPyTagged cp
     cpy_r_r10 = CPyTagged_StealAsObject(cpy_r_decimals);
     PyObject *cpy_r_r11[1] = {cpy_r_r10};
     cpy_r_r12 = (PyObject **)&cpy_r_r11;
-    cpy_r_r13 = CPyStatics[359]; /* ('value',) */
+    cpy_r_r13 = CPyStatics[361]; /* ('value',) */
     cpy_r_r14 = PyObject_Vectorcall(cpy_r_r9, cpy_r_r12, 0, cpy_r_r13);
     CPy_DECREF(cpy_r_r9);
     if (unlikely(cpy_r_r14 == NULL)) {
@@ -15103,14 +15118,14 @@ CPyL3: ;
     cpy_r_r7 = (void *)&cpy_r_r6;
     int64_t cpy_r_r8[1] = {1};
     cpy_r_r9 = (void *)&cpy_r_r8;
-    cpy_r_r10 = CPyStatics[361]; /* (('decimal', 'decimal', 'decimal'),) */
+    cpy_r_r10 = CPyStatics[363]; /* (('decimal', 'decimal', 'decimal'),) */
     cpy_r_r11 = CPyStatic_currency___globals;
-    cpy_r_r12 = CPyStatics[192]; /* 'faster_eth_utils/currency.py' */
+    cpy_r_r12 = CPyStatics[193]; /* 'faster_eth_utils/currency.py' */
     cpy_r_r13 = CPyStatics[70]; /* '<module>' */
     cpy_r_r14 = CPyImport_ImportMany(cpy_r_r10, cpy_r_r7, cpy_r_r11, cpy_r_r12, cpy_r_r13, cpy_r_r9);
     if (!cpy_r_r14) goto CPyL158;
-    cpy_r_r15 = CPyStatics[362]; /* ('localcontext',) */
-    cpy_r_r16 = CPyStatics[191]; /* 'decimal' */
+    cpy_r_r15 = CPyStatics[364]; /* ('localcontext',) */
+    cpy_r_r16 = CPyStatics[192]; /* 'decimal' */
     cpy_r_r17 = CPyStatic_currency___globals;
     cpy_r_r18 = CPyImport_ImportFromMany(cpy_r_r16, cpy_r_r15, cpy_r_r15, cpy_r_r17);
     if (unlikely(cpy_r_r18 == NULL)) {
@@ -15120,7 +15135,7 @@ CPyL3: ;
     CPyModule_decimal = cpy_r_r18;
     CPy_INCREF(CPyModule_decimal);
     CPy_DECREF(cpy_r_r18);
-    cpy_r_r19 = CPyStatics[363]; /* ('Final', 'Union', 'final') */
+    cpy_r_r19 = CPyStatics[365]; /* ('Final', 'Union', 'final') */
     cpy_r_r20 = CPyStatics[81]; /* 'typing' */
     cpy_r_r21 = CPyStatic_currency___globals;
     cpy_r_r22 = CPyImport_ImportFromMany(cpy_r_r20, cpy_r_r19, cpy_r_r19, cpy_r_r21);
@@ -15131,7 +15146,7 @@ CPyL3: ;
     CPyModule_typing = cpy_r_r22;
     CPy_INCREF(CPyModule_typing);
     CPy_DECREF(cpy_r_r22);
-    cpy_r_r23 = CPyStatics[364]; /* ('is_integer', 'is_string') */
+    cpy_r_r23 = CPyStatics[366]; /* ('is_integer', 'is_string') */
     cpy_r_r24 = CPyStatics[93]; /* 'faster_eth_utils.types' */
     cpy_r_r25 = CPyStatic_currency___globals;
     cpy_r_r26 = CPyImport_ImportFromMany(cpy_r_r24, cpy_r_r23, cpy_r_r23, cpy_r_r25);
@@ -15142,8 +15157,8 @@ CPyL3: ;
     CPyModule_faster_eth_utils___types = cpy_r_r26;
     CPy_INCREF(CPyModule_faster_eth_utils___types);
     CPy_DECREF(cpy_r_r26);
-    cpy_r_r27 = CPyStatics[365]; /* ('units',) */
-    cpy_r_r28 = CPyStatics[195]; /* 'faster_eth_utils.units' */
+    cpy_r_r27 = CPyStatics[367]; /* ('units',) */
+    cpy_r_r28 = CPyStatics[196]; /* 'faster_eth_utils.units' */
     cpy_r_r29 = CPyStatic_currency___globals;
     cpy_r_r30 = CPyImport_ImportFromMany(cpy_r_r28, cpy_r_r27, cpy_r_r27, cpy_r_r29);
     if (unlikely(cpy_r_r30 == NULL)) {
@@ -15154,7 +15169,7 @@ CPyL3: ;
     CPy_INCREF(CPyModule_faster_eth_utils___units);
     CPy_DECREF(cpy_r_r30);
     cpy_r_r31 = NULL;
-    cpy_r_r32 = CPyStatics[196]; /* 'faster_eth_utils.currency' */
+    cpy_r_r32 = CPyStatics[197]; /* 'faster_eth_utils.currency' */
     cpy_r_r33 = (PyObject *)CPyType_currency___denoms_template;
     cpy_r_r34 = CPyType_FromTemplate(cpy_r_r33, cpy_r_r31, cpy_r_r32);
     if (unlikely(cpy_r_r34 == NULL)) {
@@ -15166,30 +15181,30 @@ CPyL3: ;
         CPy_AddTraceback("faster_eth_utils/currency.py", "<module>", -1, CPyStatic_currency___globals);
         goto CPyL159;
     }
-    cpy_r_r36 = CPyStatics[197]; /* '__mypyc_attrs__' */
-    cpy_r_r37 = CPyStatics[155]; /* 'wei' */
-    cpy_r_r38 = CPyStatics[156]; /* 'kwei' */
-    cpy_r_r39 = CPyStatics[157]; /* 'babbage' */
-    cpy_r_r40 = CPyStatics[158]; /* 'femtoether' */
-    cpy_r_r41 = CPyStatics[159]; /* 'mwei' */
-    cpy_r_r42 = CPyStatics[160]; /* 'lovelace' */
-    cpy_r_r43 = CPyStatics[161]; /* 'picoether' */
-    cpy_r_r44 = CPyStatics[162]; /* 'gwei' */
-    cpy_r_r45 = CPyStatics[163]; /* 'shannon' */
-    cpy_r_r46 = CPyStatics[164]; /* 'nanoether' */
-    cpy_r_r47 = CPyStatics[165]; /* 'nano' */
-    cpy_r_r48 = CPyStatics[166]; /* 'szabo' */
-    cpy_r_r49 = CPyStatics[167]; /* 'microether' */
-    cpy_r_r50 = CPyStatics[168]; /* 'micro' */
-    cpy_r_r51 = CPyStatics[169]; /* 'finney' */
-    cpy_r_r52 = CPyStatics[170]; /* 'milliether' */
-    cpy_r_r53 = CPyStatics[171]; /* 'milli' */
-    cpy_r_r54 = CPyStatics[172]; /* 'ether' */
-    cpy_r_r55 = CPyStatics[173]; /* 'kether' */
-    cpy_r_r56 = CPyStatics[174]; /* 'grand' */
-    cpy_r_r57 = CPyStatics[175]; /* 'mether' */
-    cpy_r_r58 = CPyStatics[176]; /* 'gether' */
-    cpy_r_r59 = CPyStatics[177]; /* 'tether' */
+    cpy_r_r36 = CPyStatics[198]; /* '__mypyc_attrs__' */
+    cpy_r_r37 = CPyStatics[156]; /* 'wei' */
+    cpy_r_r38 = CPyStatics[157]; /* 'kwei' */
+    cpy_r_r39 = CPyStatics[158]; /* 'babbage' */
+    cpy_r_r40 = CPyStatics[159]; /* 'femtoether' */
+    cpy_r_r41 = CPyStatics[160]; /* 'mwei' */
+    cpy_r_r42 = CPyStatics[161]; /* 'lovelace' */
+    cpy_r_r43 = CPyStatics[162]; /* 'picoether' */
+    cpy_r_r44 = CPyStatics[163]; /* 'gwei' */
+    cpy_r_r45 = CPyStatics[164]; /* 'shannon' */
+    cpy_r_r46 = CPyStatics[165]; /* 'nanoether' */
+    cpy_r_r47 = CPyStatics[166]; /* 'nano' */
+    cpy_r_r48 = CPyStatics[167]; /* 'szabo' */
+    cpy_r_r49 = CPyStatics[168]; /* 'microether' */
+    cpy_r_r50 = CPyStatics[169]; /* 'micro' */
+    cpy_r_r51 = CPyStatics[170]; /* 'finney' */
+    cpy_r_r52 = CPyStatics[171]; /* 'milliether' */
+    cpy_r_r53 = CPyStatics[172]; /* 'milli' */
+    cpy_r_r54 = CPyStatics[173]; /* 'ether' */
+    cpy_r_r55 = CPyStatics[174]; /* 'kether' */
+    cpy_r_r56 = CPyStatics[175]; /* 'grand' */
+    cpy_r_r57 = CPyStatics[176]; /* 'mether' */
+    cpy_r_r58 = CPyStatics[177]; /* 'gether' */
+    cpy_r_r59 = CPyStatics[178]; /* 'tether' */
     cpy_r_r60 = PyTuple_Pack(23, cpy_r_r37, cpy_r_r38, cpy_r_r39, cpy_r_r40, cpy_r_r41, cpy_r_r42, cpy_r_r43, cpy_r_r44, cpy_r_r45, cpy_r_r46, cpy_r_r47, cpy_r_r48, cpy_r_r49, cpy_r_r50, cpy_r_r51, cpy_r_r52, cpy_r_r53, cpy_r_r54, cpy_r_r55, cpy_r_r56, cpy_r_r57, cpy_r_r58, cpy_r_r59);
     if (unlikely(cpy_r_r60 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/currency.py", "<module>", 21, CPyStatic_currency___globals);
@@ -15205,7 +15220,7 @@ CPyL3: ;
     CPyType_currency___denoms = (PyTypeObject *)cpy_r_r34;
     CPy_INCREF(CPyType_currency___denoms);
     cpy_r_r63 = CPyStatic_currency___globals;
-    cpy_r_r64 = CPyStatics[198]; /* 'denoms' */
+    cpy_r_r64 = CPyStatics[199]; /* 'denoms' */
     cpy_r_r65 = CPyDict_SetItem(cpy_r_r63, cpy_r_r64, cpy_r_r34);
     CPy_DECREF(cpy_r_r34);
     cpy_r_r66 = cpy_r_r65 >= 0;
@@ -15215,7 +15230,7 @@ CPyL3: ;
     }
     cpy_r_r67 = (PyObject *)CPyType_currency___denoms;
     cpy_r_r68 = CPyStatic_currency___globals;
-    cpy_r_r69 = CPyStatics[154]; /* 'units' */
+    cpy_r_r69 = CPyStatics[155]; /* 'units' */
     cpy_r_r70 = CPyDict_GetItem(cpy_r_r68, cpy_r_r69);
     if (unlikely(cpy_r_r70 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/currency.py", "<module>", 22, CPyStatic_currency___globals);
@@ -15227,7 +15242,7 @@ CPyL3: ;
         CPy_TypeErrorTraceback("faster_eth_utils/currency.py", "<module>", 22, CPyStatic_currency___globals, "dict", cpy_r_r70);
         goto CPyL158;
     }
-    cpy_r_r72 = CPyStatics[155]; /* 'wei' */
+    cpy_r_r72 = CPyStatics[156]; /* 'wei' */
     cpy_r_r73 = CPyDict_GetItem(cpy_r_r71, cpy_r_r72);
     CPy_DECREF(cpy_r_r71);
     if (unlikely(cpy_r_r73 == NULL)) {
@@ -15253,7 +15268,7 @@ CPyL3: ;
         CPy_AddTraceback("faster_eth_utils/currency.py", "<module>", 22, CPyStatic_currency___globals);
         goto CPyL158;
     }
-    cpy_r_r79 = CPyStatics[155]; /* 'wei' */
+    cpy_r_r79 = CPyStatics[156]; /* 'wei' */
     CPyTagged_INCREF(cpy_r_r78);
     cpy_r_r80 = CPyTagged_StealAsObject(cpy_r_r78);
     cpy_r_r81 = PyObject_SetAttr(cpy_r_r67, cpy_r_r79, cpy_r_r80);
@@ -15268,7 +15283,7 @@ CPyL3: ;
     CPyTagged_DECREF(cpy_r_r78);
     cpy_r_r83 = (PyObject *)CPyType_currency___denoms;
     cpy_r_r84 = CPyStatic_currency___globals;
-    cpy_r_r85 = CPyStatics[154]; /* 'units' */
+    cpy_r_r85 = CPyStatics[155]; /* 'units' */
     cpy_r_r86 = CPyDict_GetItem(cpy_r_r84, cpy_r_r85);
     if (unlikely(cpy_r_r86 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/currency.py", "<module>", 23, CPyStatic_currency___globals);
@@ -15280,7 +15295,7 @@ CPyL3: ;
         CPy_TypeErrorTraceback("faster_eth_utils/currency.py", "<module>", 23, CPyStatic_currency___globals, "dict", cpy_r_r86);
         goto CPyL158;
     }
-    cpy_r_r88 = CPyStatics[156]; /* 'kwei' */
+    cpy_r_r88 = CPyStatics[157]; /* 'kwei' */
     cpy_r_r89 = CPyDict_GetItem(cpy_r_r87, cpy_r_r88);
     CPy_DECREF(cpy_r_r87);
     if (unlikely(cpy_r_r89 == NULL)) {
@@ -15306,7 +15321,7 @@ CPyL3: ;
         CPy_AddTraceback("faster_eth_utils/currency.py", "<module>", 23, CPyStatic_currency___globals);
         goto CPyL158;
     }
-    cpy_r_r95 = CPyStatics[156]; /* 'kwei' */
+    cpy_r_r95 = CPyStatics[157]; /* 'kwei' */
     CPyTagged_INCREF(cpy_r_r94);
     cpy_r_r96 = CPyTagged_StealAsObject(cpy_r_r94);
     cpy_r_r97 = PyObject_SetAttr(cpy_r_r83, cpy_r_r95, cpy_r_r96);
@@ -15321,7 +15336,7 @@ CPyL3: ;
     CPyTagged_DECREF(cpy_r_r94);
     cpy_r_r99 = (PyObject *)CPyType_currency___denoms;
     cpy_r_r100 = CPyStatic_currency___globals;
-    cpy_r_r101 = CPyStatics[154]; /* 'units' */
+    cpy_r_r101 = CPyStatics[155]; /* 'units' */
     cpy_r_r102 = CPyDict_GetItem(cpy_r_r100, cpy_r_r101);
     if (unlikely(cpy_r_r102 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/currency.py", "<module>", 24, CPyStatic_currency___globals);
@@ -15333,7 +15348,7 @@ CPyL3: ;
         CPy_TypeErrorTraceback("faster_eth_utils/currency.py", "<module>", 24, CPyStatic_currency___globals, "dict", cpy_r_r102);
         goto CPyL158;
     }
-    cpy_r_r104 = CPyStatics[157]; /* 'babbage' */
+    cpy_r_r104 = CPyStatics[158]; /* 'babbage' */
     cpy_r_r105 = CPyDict_GetItem(cpy_r_r103, cpy_r_r104);
     CPy_DECREF(cpy_r_r103);
     if (unlikely(cpy_r_r105 == NULL)) {
@@ -15359,7 +15374,7 @@ CPyL3: ;
         CPy_AddTraceback("faster_eth_utils/currency.py", "<module>", 24, CPyStatic_currency___globals);
         goto CPyL158;
     }
-    cpy_r_r111 = CPyStatics[157]; /* 'babbage' */
+    cpy_r_r111 = CPyStatics[158]; /* 'babbage' */
     CPyTagged_INCREF(cpy_r_r110);
     cpy_r_r112 = CPyTagged_StealAsObject(cpy_r_r110);
     cpy_r_r113 = PyObject_SetAttr(cpy_r_r99, cpy_r_r111, cpy_r_r112);
@@ -15374,7 +15389,7 @@ CPyL3: ;
     CPyTagged_DECREF(cpy_r_r110);
     cpy_r_r115 = (PyObject *)CPyType_currency___denoms;
     cpy_r_r116 = CPyStatic_currency___globals;
-    cpy_r_r117 = CPyStatics[154]; /* 'units' */
+    cpy_r_r117 = CPyStatics[155]; /* 'units' */
     cpy_r_r118 = CPyDict_GetItem(cpy_r_r116, cpy_r_r117);
     if (unlikely(cpy_r_r118 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/currency.py", "<module>", 25, CPyStatic_currency___globals);
@@ -15386,7 +15401,7 @@ CPyL3: ;
         CPy_TypeErrorTraceback("faster_eth_utils/currency.py", "<module>", 25, CPyStatic_currency___globals, "dict", cpy_r_r118);
         goto CPyL158;
     }
-    cpy_r_r120 = CPyStatics[158]; /* 'femtoether' */
+    cpy_r_r120 = CPyStatics[159]; /* 'femtoether' */
     cpy_r_r121 = CPyDict_GetItem(cpy_r_r119, cpy_r_r120);
     CPy_DECREF(cpy_r_r119);
     if (unlikely(cpy_r_r121 == NULL)) {
@@ -15412,7 +15427,7 @@ CPyL3: ;
         CPy_AddTraceback("faster_eth_utils/currency.py", "<module>", 25, CPyStatic_currency___globals);
         goto CPyL158;
     }
-    cpy_r_r127 = CPyStatics[158]; /* 'femtoether' */
+    cpy_r_r127 = CPyStatics[159]; /* 'femtoether' */
     CPyTagged_INCREF(cpy_r_r126);
     cpy_r_r128 = CPyTagged_StealAsObject(cpy_r_r126);
     cpy_r_r129 = PyObject_SetAttr(cpy_r_r115, cpy_r_r127, cpy_r_r128);
@@ -15427,7 +15442,7 @@ CPyL3: ;
     CPyTagged_DECREF(cpy_r_r126);
     cpy_r_r131 = (PyObject *)CPyType_currency___denoms;
     cpy_r_r132 = CPyStatic_currency___globals;
-    cpy_r_r133 = CPyStatics[154]; /* 'units' */
+    cpy_r_r133 = CPyStatics[155]; /* 'units' */
     cpy_r_r134 = CPyDict_GetItem(cpy_r_r132, cpy_r_r133);
     if (unlikely(cpy_r_r134 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/currency.py", "<module>", 26, CPyStatic_currency___globals);
@@ -15439,7 +15454,7 @@ CPyL3: ;
         CPy_TypeErrorTraceback("faster_eth_utils/currency.py", "<module>", 26, CPyStatic_currency___globals, "dict", cpy_r_r134);
         goto CPyL158;
     }
-    cpy_r_r136 = CPyStatics[159]; /* 'mwei' */
+    cpy_r_r136 = CPyStatics[160]; /* 'mwei' */
     cpy_r_r137 = CPyDict_GetItem(cpy_r_r135, cpy_r_r136);
     CPy_DECREF(cpy_r_r135);
     if (unlikely(cpy_r_r137 == NULL)) {
@@ -15465,7 +15480,7 @@ CPyL3: ;
         CPy_AddTraceback("faster_eth_utils/currency.py", "<module>", 26, CPyStatic_currency___globals);
         goto CPyL158;
     }
-    cpy_r_r143 = CPyStatics[159]; /* 'mwei' */
+    cpy_r_r143 = CPyStatics[160]; /* 'mwei' */
     CPyTagged_INCREF(cpy_r_r142);
     cpy_r_r144 = CPyTagged_StealAsObject(cpy_r_r142);
     cpy_r_r145 = PyObject_SetAttr(cpy_r_r131, cpy_r_r143, cpy_r_r144);
@@ -15480,7 +15495,7 @@ CPyL3: ;
     CPyTagged_DECREF(cpy_r_r142);
     cpy_r_r147 = (PyObject *)CPyType_currency___denoms;
     cpy_r_r148 = CPyStatic_currency___globals;
-    cpy_r_r149 = CPyStatics[154]; /* 'units' */
+    cpy_r_r149 = CPyStatics[155]; /* 'units' */
     cpy_r_r150 = CPyDict_GetItem(cpy_r_r148, cpy_r_r149);
     if (unlikely(cpy_r_r150 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/currency.py", "<module>", 27, CPyStatic_currency___globals);
@@ -15492,7 +15507,7 @@ CPyL3: ;
         CPy_TypeErrorTraceback("faster_eth_utils/currency.py", "<module>", 27, CPyStatic_currency___globals, "dict", cpy_r_r150);
         goto CPyL158;
     }
-    cpy_r_r152 = CPyStatics[160]; /* 'lovelace' */
+    cpy_r_r152 = CPyStatics[161]; /* 'lovelace' */
     cpy_r_r153 = CPyDict_GetItem(cpy_r_r151, cpy_r_r152);
     CPy_DECREF(cpy_r_r151);
     if (unlikely(cpy_r_r153 == NULL)) {
@@ -15518,7 +15533,7 @@ CPyL3: ;
         CPy_AddTraceback("faster_eth_utils/currency.py", "<module>", 27, CPyStatic_currency___globals);
         goto CPyL158;
     }
-    cpy_r_r159 = CPyStatics[160]; /* 'lovelace' */
+    cpy_r_r159 = CPyStatics[161]; /* 'lovelace' */
     CPyTagged_INCREF(cpy_r_r158);
     cpy_r_r160 = CPyTagged_StealAsObject(cpy_r_r158);
     cpy_r_r161 = PyObject_SetAttr(cpy_r_r147, cpy_r_r159, cpy_r_r160);
@@ -15533,7 +15548,7 @@ CPyL3: ;
     CPyTagged_DECREF(cpy_r_r158);
     cpy_r_r163 = (PyObject *)CPyType_currency___denoms;
     cpy_r_r164 = CPyStatic_currency___globals;
-    cpy_r_r165 = CPyStatics[154]; /* 'units' */
+    cpy_r_r165 = CPyStatics[155]; /* 'units' */
     cpy_r_r166 = CPyDict_GetItem(cpy_r_r164, cpy_r_r165);
     if (unlikely(cpy_r_r166 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/currency.py", "<module>", 28, CPyStatic_currency___globals);
@@ -15545,7 +15560,7 @@ CPyL3: ;
         CPy_TypeErrorTraceback("faster_eth_utils/currency.py", "<module>", 28, CPyStatic_currency___globals, "dict", cpy_r_r166);
         goto CPyL158;
     }
-    cpy_r_r168 = CPyStatics[161]; /* 'picoether' */
+    cpy_r_r168 = CPyStatics[162]; /* 'picoether' */
     cpy_r_r169 = CPyDict_GetItem(cpy_r_r167, cpy_r_r168);
     CPy_DECREF(cpy_r_r167);
     if (unlikely(cpy_r_r169 == NULL)) {
@@ -15571,7 +15586,7 @@ CPyL3: ;
         CPy_AddTraceback("faster_eth_utils/currency.py", "<module>", 28, CPyStatic_currency___globals);
         goto CPyL158;
     }
-    cpy_r_r175 = CPyStatics[161]; /* 'picoether' */
+    cpy_r_r175 = CPyStatics[162]; /* 'picoether' */
     CPyTagged_INCREF(cpy_r_r174);
     cpy_r_r176 = CPyTagged_StealAsObject(cpy_r_r174);
     cpy_r_r177 = PyObject_SetAttr(cpy_r_r163, cpy_r_r175, cpy_r_r176);
@@ -15586,7 +15601,7 @@ CPyL3: ;
     CPyTagged_DECREF(cpy_r_r174);
     cpy_r_r179 = (PyObject *)CPyType_currency___denoms;
     cpy_r_r180 = CPyStatic_currency___globals;
-    cpy_r_r181 = CPyStatics[154]; /* 'units' */
+    cpy_r_r181 = CPyStatics[155]; /* 'units' */
     cpy_r_r182 = CPyDict_GetItem(cpy_r_r180, cpy_r_r181);
     if (unlikely(cpy_r_r182 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/currency.py", "<module>", 29, CPyStatic_currency___globals);
@@ -15598,7 +15613,7 @@ CPyL3: ;
         CPy_TypeErrorTraceback("faster_eth_utils/currency.py", "<module>", 29, CPyStatic_currency___globals, "dict", cpy_r_r182);
         goto CPyL158;
     }
-    cpy_r_r184 = CPyStatics[162]; /* 'gwei' */
+    cpy_r_r184 = CPyStatics[163]; /* 'gwei' */
     cpy_r_r185 = CPyDict_GetItem(cpy_r_r183, cpy_r_r184);
     CPy_DECREF(cpy_r_r183);
     if (unlikely(cpy_r_r185 == NULL)) {
@@ -15624,7 +15639,7 @@ CPyL3: ;
         CPy_AddTraceback("faster_eth_utils/currency.py", "<module>", 29, CPyStatic_currency___globals);
         goto CPyL158;
     }
-    cpy_r_r191 = CPyStatics[162]; /* 'gwei' */
+    cpy_r_r191 = CPyStatics[163]; /* 'gwei' */
     CPyTagged_INCREF(cpy_r_r190);
     cpy_r_r192 = CPyTagged_StealAsObject(cpy_r_r190);
     cpy_r_r193 = PyObject_SetAttr(cpy_r_r179, cpy_r_r191, cpy_r_r192);
@@ -15639,7 +15654,7 @@ CPyL3: ;
     CPyTagged_DECREF(cpy_r_r190);
     cpy_r_r195 = (PyObject *)CPyType_currency___denoms;
     cpy_r_r196 = CPyStatic_currency___globals;
-    cpy_r_r197 = CPyStatics[154]; /* 'units' */
+    cpy_r_r197 = CPyStatics[155]; /* 'units' */
     cpy_r_r198 = CPyDict_GetItem(cpy_r_r196, cpy_r_r197);
     if (unlikely(cpy_r_r198 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/currency.py", "<module>", 30, CPyStatic_currency___globals);
@@ -15651,7 +15666,7 @@ CPyL3: ;
         CPy_TypeErrorTraceback("faster_eth_utils/currency.py", "<module>", 30, CPyStatic_currency___globals, "dict", cpy_r_r198);
         goto CPyL158;
     }
-    cpy_r_r200 = CPyStatics[163]; /* 'shannon' */
+    cpy_r_r200 = CPyStatics[164]; /* 'shannon' */
     cpy_r_r201 = CPyDict_GetItem(cpy_r_r199, cpy_r_r200);
     CPy_DECREF(cpy_r_r199);
     if (unlikely(cpy_r_r201 == NULL)) {
@@ -15677,7 +15692,7 @@ CPyL3: ;
         CPy_AddTraceback("faster_eth_utils/currency.py", "<module>", 30, CPyStatic_currency___globals);
         goto CPyL158;
     }
-    cpy_r_r207 = CPyStatics[163]; /* 'shannon' */
+    cpy_r_r207 = CPyStatics[164]; /* 'shannon' */
     CPyTagged_INCREF(cpy_r_r206);
     cpy_r_r208 = CPyTagged_StealAsObject(cpy_r_r206);
     cpy_r_r209 = PyObject_SetAttr(cpy_r_r195, cpy_r_r207, cpy_r_r208);
@@ -15692,7 +15707,7 @@ CPyL3: ;
     CPyTagged_DECREF(cpy_r_r206);
     cpy_r_r211 = (PyObject *)CPyType_currency___denoms;
     cpy_r_r212 = CPyStatic_currency___globals;
-    cpy_r_r213 = CPyStatics[154]; /* 'units' */
+    cpy_r_r213 = CPyStatics[155]; /* 'units' */
     cpy_r_r214 = CPyDict_GetItem(cpy_r_r212, cpy_r_r213);
     if (unlikely(cpy_r_r214 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/currency.py", "<module>", 31, CPyStatic_currency___globals);
@@ -15704,7 +15719,7 @@ CPyL3: ;
         CPy_TypeErrorTraceback("faster_eth_utils/currency.py", "<module>", 31, CPyStatic_currency___globals, "dict", cpy_r_r214);
         goto CPyL158;
     }
-    cpy_r_r216 = CPyStatics[164]; /* 'nanoether' */
+    cpy_r_r216 = CPyStatics[165]; /* 'nanoether' */
     cpy_r_r217 = CPyDict_GetItem(cpy_r_r215, cpy_r_r216);
     CPy_DECREF(cpy_r_r215);
     if (unlikely(cpy_r_r217 == NULL)) {
@@ -15730,7 +15745,7 @@ CPyL3: ;
         CPy_AddTraceback("faster_eth_utils/currency.py", "<module>", 31, CPyStatic_currency___globals);
         goto CPyL158;
     }
-    cpy_r_r223 = CPyStatics[164]; /* 'nanoether' */
+    cpy_r_r223 = CPyStatics[165]; /* 'nanoether' */
     CPyTagged_INCREF(cpy_r_r222);
     cpy_r_r224 = CPyTagged_StealAsObject(cpy_r_r222);
     cpy_r_r225 = PyObject_SetAttr(cpy_r_r211, cpy_r_r223, cpy_r_r224);
@@ -15745,7 +15760,7 @@ CPyL3: ;
     CPyTagged_DECREF(cpy_r_r222);
     cpy_r_r227 = (PyObject *)CPyType_currency___denoms;
     cpy_r_r228 = CPyStatic_currency___globals;
-    cpy_r_r229 = CPyStatics[154]; /* 'units' */
+    cpy_r_r229 = CPyStatics[155]; /* 'units' */
     cpy_r_r230 = CPyDict_GetItem(cpy_r_r228, cpy_r_r229);
     if (unlikely(cpy_r_r230 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/currency.py", "<module>", 32, CPyStatic_currency___globals);
@@ -15757,7 +15772,7 @@ CPyL3: ;
         CPy_TypeErrorTraceback("faster_eth_utils/currency.py", "<module>", 32, CPyStatic_currency___globals, "dict", cpy_r_r230);
         goto CPyL158;
     }
-    cpy_r_r232 = CPyStatics[165]; /* 'nano' */
+    cpy_r_r232 = CPyStatics[166]; /* 'nano' */
     cpy_r_r233 = CPyDict_GetItem(cpy_r_r231, cpy_r_r232);
     CPy_DECREF(cpy_r_r231);
     if (unlikely(cpy_r_r233 == NULL)) {
@@ -15783,7 +15798,7 @@ CPyL3: ;
         CPy_AddTraceback("faster_eth_utils/currency.py", "<module>", 32, CPyStatic_currency___globals);
         goto CPyL158;
     }
-    cpy_r_r239 = CPyStatics[165]; /* 'nano' */
+    cpy_r_r239 = CPyStatics[166]; /* 'nano' */
     CPyTagged_INCREF(cpy_r_r238);
     cpy_r_r240 = CPyTagged_StealAsObject(cpy_r_r238);
     cpy_r_r241 = PyObject_SetAttr(cpy_r_r227, cpy_r_r239, cpy_r_r240);
@@ -15798,7 +15813,7 @@ CPyL3: ;
     CPyTagged_DECREF(cpy_r_r238);
     cpy_r_r243 = (PyObject *)CPyType_currency___denoms;
     cpy_r_r244 = CPyStatic_currency___globals;
-    cpy_r_r245 = CPyStatics[154]; /* 'units' */
+    cpy_r_r245 = CPyStatics[155]; /* 'units' */
     cpy_r_r246 = CPyDict_GetItem(cpy_r_r244, cpy_r_r245);
     if (unlikely(cpy_r_r246 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/currency.py", "<module>", 33, CPyStatic_currency___globals);
@@ -15810,7 +15825,7 @@ CPyL3: ;
         CPy_TypeErrorTraceback("faster_eth_utils/currency.py", "<module>", 33, CPyStatic_currency___globals, "dict", cpy_r_r246);
         goto CPyL158;
     }
-    cpy_r_r248 = CPyStatics[166]; /* 'szabo' */
+    cpy_r_r248 = CPyStatics[167]; /* 'szabo' */
     cpy_r_r249 = CPyDict_GetItem(cpy_r_r247, cpy_r_r248);
     CPy_DECREF(cpy_r_r247);
     if (unlikely(cpy_r_r249 == NULL)) {
@@ -15836,7 +15851,7 @@ CPyL3: ;
         CPy_AddTraceback("faster_eth_utils/currency.py", "<module>", 33, CPyStatic_currency___globals);
         goto CPyL158;
     }
-    cpy_r_r255 = CPyStatics[166]; /* 'szabo' */
+    cpy_r_r255 = CPyStatics[167]; /* 'szabo' */
     CPyTagged_INCREF(cpy_r_r254);
     cpy_r_r256 = CPyTagged_StealAsObject(cpy_r_r254);
     cpy_r_r257 = PyObject_SetAttr(cpy_r_r243, cpy_r_r255, cpy_r_r256);
@@ -15851,7 +15866,7 @@ CPyL3: ;
     CPyTagged_DECREF(cpy_r_r254);
     cpy_r_r259 = (PyObject *)CPyType_currency___denoms;
     cpy_r_r260 = CPyStatic_currency___globals;
-    cpy_r_r261 = CPyStatics[154]; /* 'units' */
+    cpy_r_r261 = CPyStatics[155]; /* 'units' */
     cpy_r_r262 = CPyDict_GetItem(cpy_r_r260, cpy_r_r261);
     if (unlikely(cpy_r_r262 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/currency.py", "<module>", 34, CPyStatic_currency___globals);
@@ -15863,7 +15878,7 @@ CPyL3: ;
         CPy_TypeErrorTraceback("faster_eth_utils/currency.py", "<module>", 34, CPyStatic_currency___globals, "dict", cpy_r_r262);
         goto CPyL158;
     }
-    cpy_r_r264 = CPyStatics[167]; /* 'microether' */
+    cpy_r_r264 = CPyStatics[168]; /* 'microether' */
     cpy_r_r265 = CPyDict_GetItem(cpy_r_r263, cpy_r_r264);
     CPy_DECREF(cpy_r_r263);
     if (unlikely(cpy_r_r265 == NULL)) {
@@ -15889,7 +15904,7 @@ CPyL3: ;
         CPy_AddTraceback("faster_eth_utils/currency.py", "<module>", 34, CPyStatic_currency___globals);
         goto CPyL158;
     }
-    cpy_r_r271 = CPyStatics[167]; /* 'microether' */
+    cpy_r_r271 = CPyStatics[168]; /* 'microether' */
     CPyTagged_INCREF(cpy_r_r270);
     cpy_r_r272 = CPyTagged_StealAsObject(cpy_r_r270);
     cpy_r_r273 = PyObject_SetAttr(cpy_r_r259, cpy_r_r271, cpy_r_r272);
@@ -15904,7 +15919,7 @@ CPyL3: ;
     CPyTagged_DECREF(cpy_r_r270);
     cpy_r_r275 = (PyObject *)CPyType_currency___denoms;
     cpy_r_r276 = CPyStatic_currency___globals;
-    cpy_r_r277 = CPyStatics[154]; /* 'units' */
+    cpy_r_r277 = CPyStatics[155]; /* 'units' */
     cpy_r_r278 = CPyDict_GetItem(cpy_r_r276, cpy_r_r277);
     if (unlikely(cpy_r_r278 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/currency.py", "<module>", 35, CPyStatic_currency___globals);
@@ -15916,7 +15931,7 @@ CPyL3: ;
         CPy_TypeErrorTraceback("faster_eth_utils/currency.py", "<module>", 35, CPyStatic_currency___globals, "dict", cpy_r_r278);
         goto CPyL158;
     }
-    cpy_r_r280 = CPyStatics[168]; /* 'micro' */
+    cpy_r_r280 = CPyStatics[169]; /* 'micro' */
     cpy_r_r281 = CPyDict_GetItem(cpy_r_r279, cpy_r_r280);
     CPy_DECREF(cpy_r_r279);
     if (unlikely(cpy_r_r281 == NULL)) {
@@ -15942,7 +15957,7 @@ CPyL3: ;
         CPy_AddTraceback("faster_eth_utils/currency.py", "<module>", 35, CPyStatic_currency___globals);
         goto CPyL158;
     }
-    cpy_r_r287 = CPyStatics[168]; /* 'micro' */
+    cpy_r_r287 = CPyStatics[169]; /* 'micro' */
     CPyTagged_INCREF(cpy_r_r286);
     cpy_r_r288 = CPyTagged_StealAsObject(cpy_r_r286);
     cpy_r_r289 = PyObject_SetAttr(cpy_r_r275, cpy_r_r287, cpy_r_r288);
@@ -15957,7 +15972,7 @@ CPyL3: ;
     CPyTagged_DECREF(cpy_r_r286);
     cpy_r_r291 = (PyObject *)CPyType_currency___denoms;
     cpy_r_r292 = CPyStatic_currency___globals;
-    cpy_r_r293 = CPyStatics[154]; /* 'units' */
+    cpy_r_r293 = CPyStatics[155]; /* 'units' */
     cpy_r_r294 = CPyDict_GetItem(cpy_r_r292, cpy_r_r293);
     if (unlikely(cpy_r_r294 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/currency.py", "<module>", 36, CPyStatic_currency___globals);
@@ -15969,7 +15984,7 @@ CPyL3: ;
         CPy_TypeErrorTraceback("faster_eth_utils/currency.py", "<module>", 36, CPyStatic_currency___globals, "dict", cpy_r_r294);
         goto CPyL158;
     }
-    cpy_r_r296 = CPyStatics[169]; /* 'finney' */
+    cpy_r_r296 = CPyStatics[170]; /* 'finney' */
     cpy_r_r297 = CPyDict_GetItem(cpy_r_r295, cpy_r_r296);
     CPy_DECREF(cpy_r_r295);
     if (unlikely(cpy_r_r297 == NULL)) {
@@ -15995,7 +16010,7 @@ CPyL3: ;
         CPy_AddTraceback("faster_eth_utils/currency.py", "<module>", 36, CPyStatic_currency___globals);
         goto CPyL158;
     }
-    cpy_r_r303 = CPyStatics[169]; /* 'finney' */
+    cpy_r_r303 = CPyStatics[170]; /* 'finney' */
     CPyTagged_INCREF(cpy_r_r302);
     cpy_r_r304 = CPyTagged_StealAsObject(cpy_r_r302);
     cpy_r_r305 = PyObject_SetAttr(cpy_r_r291, cpy_r_r303, cpy_r_r304);
@@ -16010,7 +16025,7 @@ CPyL3: ;
     CPyTagged_DECREF(cpy_r_r302);
     cpy_r_r307 = (PyObject *)CPyType_currency___denoms;
     cpy_r_r308 = CPyStatic_currency___globals;
-    cpy_r_r309 = CPyStatics[154]; /* 'units' */
+    cpy_r_r309 = CPyStatics[155]; /* 'units' */
     cpy_r_r310 = CPyDict_GetItem(cpy_r_r308, cpy_r_r309);
     if (unlikely(cpy_r_r310 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/currency.py", "<module>", 37, CPyStatic_currency___globals);
@@ -16022,7 +16037,7 @@ CPyL3: ;
         CPy_TypeErrorTraceback("faster_eth_utils/currency.py", "<module>", 37, CPyStatic_currency___globals, "dict", cpy_r_r310);
         goto CPyL158;
     }
-    cpy_r_r312 = CPyStatics[170]; /* 'milliether' */
+    cpy_r_r312 = CPyStatics[171]; /* 'milliether' */
     cpy_r_r313 = CPyDict_GetItem(cpy_r_r311, cpy_r_r312);
     CPy_DECREF(cpy_r_r311);
     if (unlikely(cpy_r_r313 == NULL)) {
@@ -16048,7 +16063,7 @@ CPyL3: ;
         CPy_AddTraceback("faster_eth_utils/currency.py", "<module>", 37, CPyStatic_currency___globals);
         goto CPyL158;
     }
-    cpy_r_r319 = CPyStatics[170]; /* 'milliether' */
+    cpy_r_r319 = CPyStatics[171]; /* 'milliether' */
     CPyTagged_INCREF(cpy_r_r318);
     cpy_r_r320 = CPyTagged_StealAsObject(cpy_r_r318);
     cpy_r_r321 = PyObject_SetAttr(cpy_r_r307, cpy_r_r319, cpy_r_r320);
@@ -16063,7 +16078,7 @@ CPyL3: ;
     CPyTagged_DECREF(cpy_r_r318);
     cpy_r_r323 = (PyObject *)CPyType_currency___denoms;
     cpy_r_r324 = CPyStatic_currency___globals;
-    cpy_r_r325 = CPyStatics[154]; /* 'units' */
+    cpy_r_r325 = CPyStatics[155]; /* 'units' */
     cpy_r_r326 = CPyDict_GetItem(cpy_r_r324, cpy_r_r325);
     if (unlikely(cpy_r_r326 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/currency.py", "<module>", 38, CPyStatic_currency___globals);
@@ -16075,7 +16090,7 @@ CPyL3: ;
         CPy_TypeErrorTraceback("faster_eth_utils/currency.py", "<module>", 38, CPyStatic_currency___globals, "dict", cpy_r_r326);
         goto CPyL158;
     }
-    cpy_r_r328 = CPyStatics[171]; /* 'milli' */
+    cpy_r_r328 = CPyStatics[172]; /* 'milli' */
     cpy_r_r329 = CPyDict_GetItem(cpy_r_r327, cpy_r_r328);
     CPy_DECREF(cpy_r_r327);
     if (unlikely(cpy_r_r329 == NULL)) {
@@ -16101,7 +16116,7 @@ CPyL3: ;
         CPy_AddTraceback("faster_eth_utils/currency.py", "<module>", 38, CPyStatic_currency___globals);
         goto CPyL158;
     }
-    cpy_r_r335 = CPyStatics[171]; /* 'milli' */
+    cpy_r_r335 = CPyStatics[172]; /* 'milli' */
     CPyTagged_INCREF(cpy_r_r334);
     cpy_r_r336 = CPyTagged_StealAsObject(cpy_r_r334);
     cpy_r_r337 = PyObject_SetAttr(cpy_r_r323, cpy_r_r335, cpy_r_r336);
@@ -16116,7 +16131,7 @@ CPyL3: ;
     CPyTagged_DECREF(cpy_r_r334);
     cpy_r_r339 = (PyObject *)CPyType_currency___denoms;
     cpy_r_r340 = CPyStatic_currency___globals;
-    cpy_r_r341 = CPyStatics[154]; /* 'units' */
+    cpy_r_r341 = CPyStatics[155]; /* 'units' */
     cpy_r_r342 = CPyDict_GetItem(cpy_r_r340, cpy_r_r341);
     if (unlikely(cpy_r_r342 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/currency.py", "<module>", 39, CPyStatic_currency___globals);
@@ -16128,7 +16143,7 @@ CPyL3: ;
         CPy_TypeErrorTraceback("faster_eth_utils/currency.py", "<module>", 39, CPyStatic_currency___globals, "dict", cpy_r_r342);
         goto CPyL158;
     }
-    cpy_r_r344 = CPyStatics[172]; /* 'ether' */
+    cpy_r_r344 = CPyStatics[173]; /* 'ether' */
     cpy_r_r345 = CPyDict_GetItem(cpy_r_r343, cpy_r_r344);
     CPy_DECREF(cpy_r_r343);
     if (unlikely(cpy_r_r345 == NULL)) {
@@ -16154,7 +16169,7 @@ CPyL3: ;
         CPy_AddTraceback("faster_eth_utils/currency.py", "<module>", 39, CPyStatic_currency___globals);
         goto CPyL158;
     }
-    cpy_r_r351 = CPyStatics[172]; /* 'ether' */
+    cpy_r_r351 = CPyStatics[173]; /* 'ether' */
     CPyTagged_INCREF(cpy_r_r350);
     cpy_r_r352 = CPyTagged_StealAsObject(cpy_r_r350);
     cpy_r_r353 = PyObject_SetAttr(cpy_r_r339, cpy_r_r351, cpy_r_r352);
@@ -16169,7 +16184,7 @@ CPyL3: ;
     CPyTagged_DECREF(cpy_r_r350);
     cpy_r_r355 = (PyObject *)CPyType_currency___denoms;
     cpy_r_r356 = CPyStatic_currency___globals;
-    cpy_r_r357 = CPyStatics[154]; /* 'units' */
+    cpy_r_r357 = CPyStatics[155]; /* 'units' */
     cpy_r_r358 = CPyDict_GetItem(cpy_r_r356, cpy_r_r357);
     if (unlikely(cpy_r_r358 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/currency.py", "<module>", 40, CPyStatic_currency___globals);
@@ -16181,7 +16196,7 @@ CPyL3: ;
         CPy_TypeErrorTraceback("faster_eth_utils/currency.py", "<module>", 40, CPyStatic_currency___globals, "dict", cpy_r_r358);
         goto CPyL158;
     }
-    cpy_r_r360 = CPyStatics[173]; /* 'kether' */
+    cpy_r_r360 = CPyStatics[174]; /* 'kether' */
     cpy_r_r361 = CPyDict_GetItem(cpy_r_r359, cpy_r_r360);
     CPy_DECREF(cpy_r_r359);
     if (unlikely(cpy_r_r361 == NULL)) {
@@ -16207,7 +16222,7 @@ CPyL3: ;
         CPy_AddTraceback("faster_eth_utils/currency.py", "<module>", 40, CPyStatic_currency___globals);
         goto CPyL158;
     }
-    cpy_r_r367 = CPyStatics[173]; /* 'kether' */
+    cpy_r_r367 = CPyStatics[174]; /* 'kether' */
     CPyTagged_INCREF(cpy_r_r366);
     cpy_r_r368 = CPyTagged_StealAsObject(cpy_r_r366);
     cpy_r_r369 = PyObject_SetAttr(cpy_r_r355, cpy_r_r367, cpy_r_r368);
@@ -16222,7 +16237,7 @@ CPyL3: ;
     CPyTagged_DECREF(cpy_r_r366);
     cpy_r_r371 = (PyObject *)CPyType_currency___denoms;
     cpy_r_r372 = CPyStatic_currency___globals;
-    cpy_r_r373 = CPyStatics[154]; /* 'units' */
+    cpy_r_r373 = CPyStatics[155]; /* 'units' */
     cpy_r_r374 = CPyDict_GetItem(cpy_r_r372, cpy_r_r373);
     if (unlikely(cpy_r_r374 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/currency.py", "<module>", 41, CPyStatic_currency___globals);
@@ -16234,7 +16249,7 @@ CPyL3: ;
         CPy_TypeErrorTraceback("faster_eth_utils/currency.py", "<module>", 41, CPyStatic_currency___globals, "dict", cpy_r_r374);
         goto CPyL158;
     }
-    cpy_r_r376 = CPyStatics[174]; /* 'grand' */
+    cpy_r_r376 = CPyStatics[175]; /* 'grand' */
     cpy_r_r377 = CPyDict_GetItem(cpy_r_r375, cpy_r_r376);
     CPy_DECREF(cpy_r_r375);
     if (unlikely(cpy_r_r377 == NULL)) {
@@ -16260,7 +16275,7 @@ CPyL3: ;
         CPy_AddTraceback("faster_eth_utils/currency.py", "<module>", 41, CPyStatic_currency___globals);
         goto CPyL158;
     }
-    cpy_r_r383 = CPyStatics[174]; /* 'grand' */
+    cpy_r_r383 = CPyStatics[175]; /* 'grand' */
     CPyTagged_INCREF(cpy_r_r382);
     cpy_r_r384 = CPyTagged_StealAsObject(cpy_r_r382);
     cpy_r_r385 = PyObject_SetAttr(cpy_r_r371, cpy_r_r383, cpy_r_r384);
@@ -16275,7 +16290,7 @@ CPyL3: ;
     CPyTagged_DECREF(cpy_r_r382);
     cpy_r_r387 = (PyObject *)CPyType_currency___denoms;
     cpy_r_r388 = CPyStatic_currency___globals;
-    cpy_r_r389 = CPyStatics[154]; /* 'units' */
+    cpy_r_r389 = CPyStatics[155]; /* 'units' */
     cpy_r_r390 = CPyDict_GetItem(cpy_r_r388, cpy_r_r389);
     if (unlikely(cpy_r_r390 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/currency.py", "<module>", 42, CPyStatic_currency___globals);
@@ -16287,7 +16302,7 @@ CPyL3: ;
         CPy_TypeErrorTraceback("faster_eth_utils/currency.py", "<module>", 42, CPyStatic_currency___globals, "dict", cpy_r_r390);
         goto CPyL158;
     }
-    cpy_r_r392 = CPyStatics[175]; /* 'mether' */
+    cpy_r_r392 = CPyStatics[176]; /* 'mether' */
     cpy_r_r393 = CPyDict_GetItem(cpy_r_r391, cpy_r_r392);
     CPy_DECREF(cpy_r_r391);
     if (unlikely(cpy_r_r393 == NULL)) {
@@ -16313,7 +16328,7 @@ CPyL3: ;
         CPy_AddTraceback("faster_eth_utils/currency.py", "<module>", 42, CPyStatic_currency___globals);
         goto CPyL158;
     }
-    cpy_r_r399 = CPyStatics[175]; /* 'mether' */
+    cpy_r_r399 = CPyStatics[176]; /* 'mether' */
     CPyTagged_INCREF(cpy_r_r398);
     cpy_r_r400 = CPyTagged_StealAsObject(cpy_r_r398);
     cpy_r_r401 = PyObject_SetAttr(cpy_r_r387, cpy_r_r399, cpy_r_r400);
@@ -16328,7 +16343,7 @@ CPyL3: ;
     CPyTagged_DECREF(cpy_r_r398);
     cpy_r_r403 = (PyObject *)CPyType_currency___denoms;
     cpy_r_r404 = CPyStatic_currency___globals;
-    cpy_r_r405 = CPyStatics[154]; /* 'units' */
+    cpy_r_r405 = CPyStatics[155]; /* 'units' */
     cpy_r_r406 = CPyDict_GetItem(cpy_r_r404, cpy_r_r405);
     if (unlikely(cpy_r_r406 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/currency.py", "<module>", 43, CPyStatic_currency___globals);
@@ -16340,7 +16355,7 @@ CPyL3: ;
         CPy_TypeErrorTraceback("faster_eth_utils/currency.py", "<module>", 43, CPyStatic_currency___globals, "dict", cpy_r_r406);
         goto CPyL158;
     }
-    cpy_r_r408 = CPyStatics[176]; /* 'gether' */
+    cpy_r_r408 = CPyStatics[177]; /* 'gether' */
     cpy_r_r409 = CPyDict_GetItem(cpy_r_r407, cpy_r_r408);
     CPy_DECREF(cpy_r_r407);
     if (unlikely(cpy_r_r409 == NULL)) {
@@ -16366,7 +16381,7 @@ CPyL3: ;
         CPy_AddTraceback("faster_eth_utils/currency.py", "<module>", 43, CPyStatic_currency___globals);
         goto CPyL158;
     }
-    cpy_r_r415 = CPyStatics[176]; /* 'gether' */
+    cpy_r_r415 = CPyStatics[177]; /* 'gether' */
     CPyTagged_INCREF(cpy_r_r414);
     cpy_r_r416 = CPyTagged_StealAsObject(cpy_r_r414);
     cpy_r_r417 = PyObject_SetAttr(cpy_r_r403, cpy_r_r415, cpy_r_r416);
@@ -16381,7 +16396,7 @@ CPyL3: ;
     CPyTagged_DECREF(cpy_r_r414);
     cpy_r_r419 = (PyObject *)CPyType_currency___denoms;
     cpy_r_r420 = CPyStatic_currency___globals;
-    cpy_r_r421 = CPyStatics[154]; /* 'units' */
+    cpy_r_r421 = CPyStatics[155]; /* 'units' */
     cpy_r_r422 = CPyDict_GetItem(cpy_r_r420, cpy_r_r421);
     if (unlikely(cpy_r_r422 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/currency.py", "<module>", 44, CPyStatic_currency___globals);
@@ -16393,7 +16408,7 @@ CPyL3: ;
         CPy_TypeErrorTraceback("faster_eth_utils/currency.py", "<module>", 44, CPyStatic_currency___globals, "dict", cpy_r_r422);
         goto CPyL158;
     }
-    cpy_r_r424 = CPyStatics[177]; /* 'tether' */
+    cpy_r_r424 = CPyStatics[178]; /* 'tether' */
     cpy_r_r425 = CPyDict_GetItem(cpy_r_r423, cpy_r_r424);
     CPy_DECREF(cpy_r_r423);
     if (unlikely(cpy_r_r425 == NULL)) {
@@ -16419,7 +16434,7 @@ CPyL3: ;
         CPy_AddTraceback("faster_eth_utils/currency.py", "<module>", 44, CPyStatic_currency___globals);
         goto CPyL158;
     }
-    cpy_r_r431 = CPyStatics[177]; /* 'tether' */
+    cpy_r_r431 = CPyStatics[178]; /* 'tether' */
     CPyTagged_INCREF(cpy_r_r430);
     cpy_r_r432 = CPyTagged_StealAsObject(cpy_r_r430);
     cpy_r_r433 = PyObject_SetAttr(cpy_r_r419, cpy_r_r431, cpy_r_r432);
@@ -16433,17 +16448,17 @@ CPyL3: ;
     CPyTagged_INCREF(CPyStatic_currency___denoms___tether);
     CPyTagged_DECREF(cpy_r_r430);
     cpy_r_r435 = CPyStatic_currency___globals;
-    cpy_r_r436 = CPyStatics[199]; /* 'MIN_WEI' */
-    cpy_r_r437 = CPyStatics[322]; /* 0 */
+    cpy_r_r436 = CPyStatics[200]; /* 'MIN_WEI' */
+    cpy_r_r437 = CPyStatics[323]; /* 0 */
     cpy_r_r438 = CPyDict_SetItem(cpy_r_r435, cpy_r_r436, cpy_r_r437);
     cpy_r_r439 = cpy_r_r438 >= 0;
     if (unlikely(!cpy_r_r439)) {
         CPy_AddTraceback("faster_eth_utils/currency.py", "<module>", 47, CPyStatic_currency___globals);
         goto CPyL158;
     }
-    cpy_r_r440 = (CPyTagged)CPyStatics[323] | 1; /* 115792089237316195423570985008687907853269984665640564039457584007913129639935 */
+    cpy_r_r440 = (CPyTagged)CPyStatics[324] | 1; /* 115792089237316195423570985008687907853269984665640564039457584007913129639935 */
     cpy_r_r441 = CPyStatic_currency___globals;
-    cpy_r_r442 = CPyStatics[200]; /* 'MAX_WEI' */
+    cpy_r_r442 = CPyStatics[201]; /* 'MAX_WEI' */
     CPyTagged_INCREF(cpy_r_r440);
     cpy_r_r443 = CPyTagged_StealAsObject(cpy_r_r440);
     cpy_r_r444 = CPyDict_SetItem(cpy_r_r441, cpy_r_r442, cpy_r_r443);
@@ -16464,7 +16479,7 @@ CPyL3: ;
     cpy_r_r450 = (PyObject *)&PyFloat_Type;
     cpy_r_r451 = (PyObject *)&PyUnicode_Type;
     cpy_r_r452 = CPyModule_decimal;
-    cpy_r_r453 = CPyStatics[183]; /* 'Decimal' */
+    cpy_r_r453 = CPyStatics[184]; /* 'Decimal' */
     cpy_r_r454 = CPyObject_GetAttr(cpy_r_r452, cpy_r_r453);
     if (unlikely(cpy_r_r454 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/currency.py", "<module>", 50, CPyStatic_currency___globals);
@@ -16496,7 +16511,7 @@ CPyL3: ;
         goto CPyL158;
     }
     cpy_r_r458 = CPyStatic_currency___globals;
-    cpy_r_r459 = CPyStatics[201]; /* '_NumberType' */
+    cpy_r_r459 = CPyStatics[202]; /* '_NumberType' */
     cpy_r_r460 = CPyDict_SetItem(cpy_r_r458, cpy_r_r459, cpy_r_r457);
     CPy_DECREF(cpy_r_r457);
     cpy_r_r461 = cpy_r_r460 >= 0;
@@ -16718,14 +16733,14 @@ PyObject *CPyDef_debug___pip_freeze(void) {
     PyObject *cpy_r_r18;
     PyObject *cpy_r_r19;
     PyObject *cpy_r_r20;
-    cpy_r_r0 = CPyStatics[202]; /* 'python -m pip freeze' */
+    cpy_r_r0 = CPyStatics[203]; /* 'python -m pip freeze' */
     cpy_r_r1 = PyUnicode_Split(cpy_r_r0, NULL, -1);
     if (unlikely(cpy_r_r1 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/debug.py", "pip_freeze", 7, CPyStatic_debug___globals);
         goto CPyL10;
     }
     cpy_r_r2 = CPyModule_subprocess;
-    cpy_r_r3 = CPyStatics[203]; /* 'PIPE' */
+    cpy_r_r3 = CPyStatics[204]; /* 'PIPE' */
     cpy_r_r4 = CPyObject_GetAttr(cpy_r_r2, cpy_r_r3);
     if (unlikely(cpy_r_r4 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/debug.py", "pip_freeze", 7, CPyStatic_debug___globals);
@@ -16742,7 +16757,7 @@ PyObject *CPyDef_debug___pip_freeze(void) {
         goto CPyL11;
     }
     cpy_r_r6 = CPyModule_subprocess;
-    cpy_r_r7 = CPyStatics[204]; /* 'run' */
+    cpy_r_r7 = CPyStatics[205]; /* 'run' */
     cpy_r_r8 = CPyObject_GetAttr(cpy_r_r6, cpy_r_r7);
     if (unlikely(cpy_r_r8 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/debug.py", "pip_freeze", 7, CPyStatic_debug___globals);
@@ -16751,7 +16766,7 @@ PyObject *CPyDef_debug___pip_freeze(void) {
     cpy_r_r9 = CPyTagged_StealAsObject(cpy_r_r5);
     PyObject *cpy_r_r10[2] = {cpy_r_r1, cpy_r_r9};
     cpy_r_r11 = (PyObject **)&cpy_r_r10;
-    cpy_r_r12 = CPyStatics[366]; /* ('stdout',) */
+    cpy_r_r12 = CPyStatics[368]; /* ('stdout',) */
     cpy_r_r13 = PyObject_Vectorcall(cpy_r_r8, cpy_r_r11, 1, cpy_r_r12);
     CPy_DECREF(cpy_r_r8);
     if (unlikely(cpy_r_r13 == NULL)) {
@@ -16760,8 +16775,8 @@ PyObject *CPyDef_debug___pip_freeze(void) {
     }
     CPy_DECREF_NO_IMM(cpy_r_r1);
     CPy_DECREF(cpy_r_r9);
-    cpy_r_r14 = CPyStatics[206]; /* 'python -m pip freeze result:\n' */
-    cpy_r_r15 = CPyStatics[205]; /* 'stdout' */
+    cpy_r_r14 = CPyStatics[207]; /* 'python -m pip freeze result:\n' */
+    cpy_r_r15 = CPyStatics[206]; /* 'stdout' */
     cpy_r_r16 = CPyObject_GetAttr(cpy_r_r13, cpy_r_r15);
     CPy_DECREF(cpy_r_r13);
     if (unlikely(cpy_r_r16 == NULL)) {
@@ -16824,9 +16839,9 @@ PyObject *CPyDef_debug___python_version(void) {
     PyObject *cpy_r_r4;
     PyObject *cpy_r_r5;
     PyObject *cpy_r_r6;
-    cpy_r_r0 = CPyStatics[207]; /* 'Python version:\n' */
+    cpy_r_r0 = CPyStatics[208]; /* 'Python version:\n' */
     cpy_r_r1 = CPyModule_sys;
-    cpy_r_r2 = CPyStatics[208]; /* 'version' */
+    cpy_r_r2 = CPyStatics[209]; /* 'version' */
     cpy_r_r3 = CPyObject_GetAttr(cpy_r_r1, cpy_r_r2);
     if (unlikely(cpy_r_r3 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/debug.py", "python_version", 12, CPyStatic_debug___globals);
@@ -16872,9 +16887,9 @@ PyObject *CPyDef_debug___platform_info(void) {
     PyObject *cpy_r_r5;
     PyObject *cpy_r_r6;
     PyObject *cpy_r_r7;
-    cpy_r_r0 = CPyStatics[209]; /* 'Operating System: ' */
+    cpy_r_r0 = CPyStatics[210]; /* 'Operating System: ' */
     cpy_r_r1 = CPyModule_platform;
-    cpy_r_r2 = CPyStatics[210]; /* 'platform' */
+    cpy_r_r2 = CPyStatics[211]; /* 'platform' */
     cpy_r_r3 = CPyObject_GetAttr(cpy_r_r1, cpy_r_r2);
     if (unlikely(cpy_r_r3 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/debug.py", "platform_info", 16, CPyStatic_debug___globals);
@@ -16929,7 +16944,7 @@ PyObject *CPyDef_debug___get_environment_summary(void) {
     CPyPtr cpy_r_r8;
     PyObject *cpy_r_r9;
     PyObject *cpy_r_r10;
-    cpy_r_r0 = CPyStatics[211]; /* '\n\n' */
+    cpy_r_r0 = CPyStatics[212]; /* '\n\n' */
     cpy_r_r1 = CPyDef_debug___python_version();
     if (unlikely(cpy_r_r1 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/debug.py", "get_environment_summary", 20, CPyStatic_debug___globals);
@@ -17032,11 +17047,11 @@ CPyL3: ;
     cpy_r_r9 = (void *)&cpy_r_r8;
     int64_t cpy_r_r10[3] = {1, 2, 3};
     cpy_r_r11 = (void *)&cpy_r_r10;
-    cpy_r_r12 = CPyStatics[370]; /* (('platform', 'platform', 'platform'),
+    cpy_r_r12 = CPyStatics[372]; /* (('platform', 'platform', 'platform'),
                                     ('subprocess', 'subprocess', 'subprocess'),
                                     ('sys', 'sys', 'sys')) */
     cpy_r_r13 = CPyStatic_debug___globals;
-    cpy_r_r14 = CPyStatics[214]; /* 'faster_eth_utils/debug.py' */
+    cpy_r_r14 = CPyStatics[215]; /* 'faster_eth_utils/debug.py' */
     cpy_r_r15 = CPyStatics[70]; /* '<module>' */
     cpy_r_r16 = CPyImport_ImportMany(cpy_r_r12, cpy_r_r9, cpy_r_r13, cpy_r_r14, cpy_r_r15, cpy_r_r11);
     if (!cpy_r_r16) goto CPyL5;
@@ -18691,7 +18706,7 @@ CPyL4: ;
         goto CPyL25;
     }
 CPyL5: ;
-    cpy_r_r6 = CPyStatics[215]; /* 'method' */
+    cpy_r_r6 = CPyStatics[216]; /* 'method' */
     cpy_r_r7 = CPyObject_GetAttr(cpy_r_r4, cpy_r_r6);
     CPy_DECREF_NO_IMM(cpy_r_r4);
     if (unlikely(cpy_r_r7 == NULL)) {
@@ -18759,7 +18774,7 @@ CPyL14: ;
         goto CPyL32;
     }
 CPyL15: ;
-    cpy_r_r19 = CPyStatics[215]; /* 'method' */
+    cpy_r_r19 = CPyStatics[216]; /* 'method' */
     cpy_r_r20 = CPyObject_GetAttr(cpy_r_r17, cpy_r_r19);
     CPy_DECREF_NO_IMM(cpy_r_r17);
     if (unlikely(cpy_r_r20 == NULL)) {
@@ -18985,7 +19000,7 @@ CPyL11: ;
     CPy_INCREF(cpy_r_r9);
     CPy_DECREF_NO_IMM(cpy_r_r8);
     cpy_r_r10 = CPyModule_functools;
-    cpy_r_r11 = CPyStatics[216]; /* 'wraps' */
+    cpy_r_r11 = CPyStatics[217]; /* 'wraps' */
     cpy_r_r12 = CPyObject_GetAttr(cpy_r_r10, cpy_r_r11);
     if (unlikely(cpy_r_r12 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/decorators.py", "__get__", 29, CPyStatic_decorators___globals);
@@ -19011,7 +19026,7 @@ CPyL11: ;
     CPy_DECREF_NO_IMM(cpy_r_r6);
     CPy_INCREF(cpy_r_r18);
     cpy_r_r19 = CPyStatic_decorators___globals;
-    cpy_r_r20 = CPyStatics[217]; /* '_wrapper' */
+    cpy_r_r20 = CPyStatics[218]; /* '_wrapper' */
     cpy_r_r21 = CPyDict_SetItem(cpy_r_r19, cpy_r_r20, cpy_r_r18);
     CPy_DECREF(cpy_r_r18);
     cpy_r_r22 = cpy_r_r21 >= 0;
@@ -19441,7 +19456,7 @@ CPyL1: ;
     }
 CPyL7: ;
     cpy_r_r7 = CPyModule_functools;
-    cpy_r_r8 = CPyStatics[216]; /* 'wraps' */
+    cpy_r_r8 = CPyStatics[217]; /* 'wraps' */
     cpy_r_r9 = CPyObject_GetAttr(cpy_r_r7, cpy_r_r8);
     if (unlikely(cpy_r_r9 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/decorators.py", "decorator", 45, CPyStatic_decorators___globals);
@@ -19467,7 +19482,7 @@ CPyL7: ;
     CPy_DECREF_NO_IMM(cpy_r_r4);
     CPy_INCREF(cpy_r_r15);
     cpy_r_r16 = CPyStatic_decorators___globals;
-    cpy_r_r17 = CPyStatics[218]; /* 'wrapper' */
+    cpy_r_r17 = CPyStatics[219]; /* 'wrapper' */
     cpy_r_r18 = CPyDict_SetItem(cpy_r_r16, cpy_r_r17, cpy_r_r15);
     CPy_DECREF(cpy_r_r15);
     cpy_r_r19 = cpy_r_r18 >= 0;
@@ -19780,7 +19795,7 @@ CPyL17: ;
 CPyL18: ;
     cpy_r_r20 = CPy_CatchError();
     cpy_r_r21 = CPyModule_builtins;
-    cpy_r_r22 = CPyStatics[219]; /* 'KeyError' */
+    cpy_r_r22 = CPyStatics[220]; /* 'KeyError' */
     cpy_r_r23 = CPyObject_GetAttr(cpy_r_r21, cpy_r_r22);
     if (unlikely(cpy_r_r23 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/decorators.py", "wrapped", 72, CPyStatic_decorators___globals);
@@ -19789,7 +19804,7 @@ CPyL18: ;
     cpy_r_r24 = CPy_ExceptionMatches(cpy_r_r23);
     CPy_DecRef(cpy_r_r23);
     if (!cpy_r_r24) goto CPyL46;
-    cpy_r_r25 = CPyStatics[220]; /* 'could not look up new exception to use for ' */
+    cpy_r_r25 = CPyStatics[221]; /* 'could not look up new exception to use for ' */
     cpy_r_r26 = PyObject_Repr(cpy_r_r13);
     CPy_DecRef(cpy_r_r13);
     if (unlikely(cpy_r_r26 == NULL)) {
@@ -20080,7 +20095,7 @@ CPyL1: ;
     }
 CPyL7: ;
     cpy_r_r7 = CPyModule_functools;
-    cpy_r_r8 = CPyStatics[216]; /* 'wraps' */
+    cpy_r_r8 = CPyStatics[217]; /* 'wraps' */
     cpy_r_r9 = CPyObject_GetAttr(cpy_r_r7, cpy_r_r8);
     if (unlikely(cpy_r_r9 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/decorators.py", "decorator", 65, CPyStatic_decorators___globals);
@@ -20106,7 +20121,7 @@ CPyL7: ;
     CPy_DECREF_NO_IMM(cpy_r_r4);
     CPy_INCREF(cpy_r_r15);
     cpy_r_r16 = CPyStatic_decorators___globals;
-    cpy_r_r17 = CPyStatics[221]; /* 'wrapped' */
+    cpy_r_r17 = CPyStatics[222]; /* 'wrapped' */
     cpy_r_r18 = CPyDict_SetItem(cpy_r_r16, cpy_r_r17, cpy_r_r15);
     CPy_DECREF(cpy_r_r15);
     cpy_r_r19 = cpy_r_r18 >= 0;
@@ -20329,15 +20344,15 @@ CPyL3: ;
     cpy_r_r9 = (void *)&cpy_r_r8;
     int64_t cpy_r_r10[3] = {1, 2, 3};
     cpy_r_r11 = (void *)&cpy_r_r10;
-    cpy_r_r12 = CPyStatics[373]; /* (('functools', 'functools', 'functools'),
+    cpy_r_r12 = CPyStatics[375]; /* (('functools', 'functools', 'functools'),
                                     ('itertools', 'itertools', 'itertools'),
                                     ('os', 'os', 'os')) */
     cpy_r_r13 = CPyStatic_decorators___globals;
-    cpy_r_r14 = CPyStatics[224]; /* 'faster_eth_utils/decorators.py' */
+    cpy_r_r14 = CPyStatics[225]; /* 'faster_eth_utils/decorators.py' */
     cpy_r_r15 = CPyStatics[70]; /* '<module>' */
     cpy_r_r16 = CPyImport_ImportMany(cpy_r_r12, cpy_r_r9, cpy_r_r13, cpy_r_r14, cpy_r_r15, cpy_r_r11);
     if (!cpy_r_r16) goto CPyL15;
-    cpy_r_r17 = CPyStatics[374]; /* ('Any', 'Callable', 'Dict', 'Optional', 'Type', 'TypeVar',
+    cpy_r_r17 = CPyStatics[376]; /* ('Any', 'Callable', 'Dict', 'Optional', 'Type', 'TypeVar',
                                     'final') */
     cpy_r_r18 = CPyStatics[81]; /* 'typing' */
     cpy_r_r19 = CPyStatic_decorators___globals;
@@ -20349,7 +20364,7 @@ CPyL3: ;
     CPyModule_typing = cpy_r_r20;
     CPy_INCREF(CPyModule_typing);
     CPy_DECREF(cpy_r_r20);
-    cpy_r_r21 = CPyStatics[375]; /* ('is_text',) */
+    cpy_r_r21 = CPyStatics[377]; /* ('is_text',) */
     cpy_r_r22 = CPyStatics[93]; /* 'faster_eth_utils.types' */
     cpy_r_r23 = CPyStatic_decorators___globals;
     cpy_r_r24 = CPyImport_ImportFromMany(cpy_r_r22, cpy_r_r21, cpy_r_r21, cpy_r_r23);
@@ -20360,9 +20375,9 @@ CPyL3: ;
     CPyModule_faster_eth_utils___types = cpy_r_r24;
     CPy_INCREF(CPyModule_faster_eth_utils___types);
     CPy_DECREF(cpy_r_r24);
-    cpy_r_r25 = CPyStatics[152]; /* 'T' */
+    cpy_r_r25 = CPyStatics[153]; /* 'T' */
     cpy_r_r26 = CPyStatic_decorators___globals;
-    cpy_r_r27 = CPyStatics[145]; /* 'TypeVar' */
+    cpy_r_r27 = CPyStatics[146]; /* 'TypeVar' */
     cpy_r_r28 = CPyDict_GetItem(cpy_r_r26, cpy_r_r27);
     if (unlikely(cpy_r_r28 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/decorators.py", "<module>", 18, CPyStatic_decorators___globals);
@@ -20377,7 +20392,7 @@ CPyL3: ;
         goto CPyL15;
     }
     cpy_r_r32 = CPyStatic_decorators___globals;
-    cpy_r_r33 = CPyStatics[152]; /* 'T' */
+    cpy_r_r33 = CPyStatics[153]; /* 'T' */
     cpy_r_r34 = CPyDict_SetItem(cpy_r_r32, cpy_r_r33, cpy_r_r31);
     CPy_DECREF(cpy_r_r31);
     cpy_r_r35 = cpy_r_r34 >= 0;
@@ -20386,7 +20401,7 @@ CPyL3: ;
         goto CPyL15;
     }
     cpy_r_r36 = NULL;
-    cpy_r_r37 = CPyStatics[226]; /* 'faster_eth_utils.decorators' */
+    cpy_r_r37 = CPyStatics[227]; /* 'faster_eth_utils.decorators' */
     cpy_r_r38 = (PyObject *)CPyType_decorators___combomethod_template;
     cpy_r_r39 = CPyType_FromTemplate(cpy_r_r38, cpy_r_r36, cpy_r_r37);
     if (unlikely(cpy_r_r39 == NULL)) {
@@ -20398,8 +20413,8 @@ CPyL3: ;
         CPy_AddTraceback("faster_eth_utils/decorators.py", "<module>", -1, CPyStatic_decorators___globals);
         goto CPyL16;
     }
-    cpy_r_r41 = CPyStatics[197]; /* '__mypyc_attrs__' */
-    cpy_r_r42 = CPyStatics[215]; /* 'method' */
+    cpy_r_r41 = CPyStatics[198]; /* '__mypyc_attrs__' */
+    cpy_r_r42 = CPyStatics[216]; /* 'method' */
     cpy_r_r43 = PyTuple_Pack(1, cpy_r_r42);
     if (unlikely(cpy_r_r43 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/decorators.py", "<module>", 22, CPyStatic_decorators___globals);
@@ -20415,7 +20430,7 @@ CPyL3: ;
     CPyType_decorators___combomethod = (PyTypeObject *)cpy_r_r39;
     CPy_INCREF(CPyType_decorators___combomethod);
     cpy_r_r46 = CPyStatic_decorators___globals;
-    cpy_r_r47 = CPyStatics[227]; /* 'combomethod' */
+    cpy_r_r47 = CPyStatics[228]; /* 'combomethod' */
     cpy_r_r48 = CPyDict_SetItem(cpy_r_r46, cpy_r_r47, cpy_r_r39);
     CPy_DECREF(cpy_r_r39);
     cpy_r_r49 = cpy_r_r48 >= 0;
@@ -20491,7 +20506,7 @@ PyObject *CPyDef_encoding___int_to_big_endian(CPyTagged cpy_r_value) {
     PyObject *cpy_r_r16;
     PyObject *cpy_r_r17;
     PyObject *cpy_r_r18;
-    cpy_r_r0 = CPyStatics[228]; /* 'bit_length' */
+    cpy_r_r0 = CPyStatics[229]; /* 'bit_length' */
     CPyTagged_INCREF(cpy_r_value);
     cpy_r_r1 = CPyTagged_StealAsObject(cpy_r_value);
     PyObject *cpy_r_r2[1] = {cpy_r_r1};
@@ -20527,8 +20542,8 @@ PyObject *CPyDef_encoding___int_to_big_endian(CPyTagged cpy_r_value) {
 CPyL5: ;
     cpy_r_r9 = 2;
 CPyL6: ;
-    cpy_r_r10 = CPyStatics[229]; /* 'big' */
-    cpy_r_r11 = CPyStatics[230]; /* 'to_bytes' */
+    cpy_r_r10 = CPyStatics[230]; /* 'big' */
+    cpy_r_r11 = CPyStatics[231]; /* 'to_bytes' */
     CPyTagged_INCREF(cpy_r_value);
     cpy_r_r12 = CPyTagged_StealAsObject(cpy_r_value);
     cpy_r_r13 = CPyTagged_StealAsObject(cpy_r_r9);
@@ -20592,8 +20607,8 @@ CPyTagged CPyDef_encoding___big_endian_to_int(PyObject *cpy_r_value) {
     CPyTagged cpy_r_r6;
     CPyTagged cpy_r_r7;
     cpy_r_r0 = (PyObject *)&PyLong_Type;
-    cpy_r_r1 = CPyStatics[229]; /* 'big' */
-    cpy_r_r2 = CPyStatics[231]; /* 'from_bytes' */
+    cpy_r_r1 = CPyStatics[230]; /* 'big' */
+    cpy_r_r2 = CPyStatics[232]; /* 'from_bytes' */
     PyObject *cpy_r_r3[3] = {cpy_r_r0, cpy_r_value, cpy_r_r1};
     cpy_r_r4 = (PyObject **)&cpy_r_r3;
     cpy_r_r5 = PyObject_VectorcallMethod(cpy_r_r2, cpy_r_r4, 9223372036854775811ULL, 0);
@@ -20776,7 +20791,7 @@ char CPyDef_exceptions_____top_level__(void) {
     CPy_DECREF(cpy_r_r4);
 CPyL3: ;
     cpy_r_r5 = CPyModule_builtins;
-    cpy_r_r6 = CPyStatics[232]; /* 'Exception' */
+    cpy_r_r6 = CPyStatics[233]; /* 'Exception' */
     cpy_r_r7 = CPyObject_GetAttr(cpy_r_r5, cpy_r_r6);
     if (unlikely(cpy_r_r7 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/exceptions.py", "<module>", 1, CPyStatic_exceptions___globals);
@@ -20788,7 +20803,7 @@ CPyL3: ;
         CPy_AddTraceback("faster_eth_utils/exceptions.py", "<module>", 1, CPyStatic_exceptions___globals);
         goto CPyL10;
     }
-    cpy_r_r9 = CPyStatics[233]; /* 'faster_eth_utils.exceptions' */
+    cpy_r_r9 = CPyStatics[234]; /* 'faster_eth_utils.exceptions' */
     cpy_r_r10 = (PyObject *)CPyType_exceptions___ValidationError_template;
     cpy_r_r11 = CPyType_FromTemplate(cpy_r_r10, cpy_r_r8, cpy_r_r9);
     CPy_DECREF(cpy_r_r8);
@@ -20796,8 +20811,8 @@ CPyL3: ;
         CPy_AddTraceback("faster_eth_utils/exceptions.py", "<module>", 1, CPyStatic_exceptions___globals);
         goto CPyL10;
     }
-    cpy_r_r12 = CPyStatics[197]; /* '__mypyc_attrs__' */
-    cpy_r_r13 = CPyStatics[234]; /* '__dict__' */
+    cpy_r_r12 = CPyStatics[198]; /* '__mypyc_attrs__' */
+    cpy_r_r13 = CPyStatics[235]; /* '__dict__' */
     cpy_r_r14 = PyTuple_Pack(1, cpy_r_r13);
     if (unlikely(cpy_r_r14 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/exceptions.py", "<module>", 1, CPyStatic_exceptions___globals);
@@ -20813,7 +20828,7 @@ CPyL3: ;
     CPyType_exceptions___ValidationError = (PyTypeObject *)cpy_r_r11;
     CPy_INCREF(CPyType_exceptions___ValidationError);
     cpy_r_r17 = CPyStatic_exceptions___globals;
-    cpy_r_r18 = CPyStatics[235]; /* 'ValidationError' */
+    cpy_r_r18 = CPyStatics[236]; /* 'ValidationError' */
     cpy_r_r19 = CPyDict_SetItem(cpy_r_r17, cpy_r_r18, cpy_r_r11);
     CPy_DECREF(cpy_r_r11);
     cpy_r_r20 = cpy_r_r19 >= 0;
@@ -20909,17 +20924,17 @@ PyObject *CPyDef_hexadecimal___decode_hex(PyObject *cpy_r_value) {
     cpy_r_r1 = PyObject_IsInstance(cpy_r_value, cpy_r_r0);
     cpy_r_r2 = cpy_r_r1 >= 0;
     if (unlikely(!cpy_r_r2)) {
-        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "decode_hex", 29, CPyStatic_hexadecimal___globals);
+        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "decode_hex", 31, CPyStatic_hexadecimal___globals);
         goto CPyL15;
     }
     cpy_r_r3 = cpy_r_r1;
     if (cpy_r_r3) goto CPyL6;
-    cpy_r_r4 = CPyStatics[236]; /* 'Value must be an instance of str' */
+    cpy_r_r4 = CPyStatics[237]; /* 'Value must be an instance of str' */
     cpy_r_r5 = CPyModule_builtins;
     cpy_r_r6 = CPyStatics[16]; /* 'TypeError' */
     cpy_r_r7 = CPyObject_GetAttr(cpy_r_r5, cpy_r_r6);
     if (unlikely(cpy_r_r7 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "decode_hex", 30, CPyStatic_hexadecimal___globals);
+        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "decode_hex", 32, CPyStatic_hexadecimal___globals);
         goto CPyL15;
     }
     PyObject *cpy_r_r8[1] = {cpy_r_r4};
@@ -20927,36 +20942,36 @@ PyObject *CPyDef_hexadecimal___decode_hex(PyObject *cpy_r_value) {
     cpy_r_r10 = PyObject_Vectorcall(cpy_r_r7, cpy_r_r9, 1, 0);
     CPy_DECREF(cpy_r_r7);
     if (unlikely(cpy_r_r10 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "decode_hex", 30, CPyStatic_hexadecimal___globals);
+        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "decode_hex", 32, CPyStatic_hexadecimal___globals);
         goto CPyL15;
     }
     CPy_Raise(cpy_r_r10);
     CPy_DECREF(cpy_r_r10);
     if (unlikely(!0)) {
-        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "decode_hex", 30, CPyStatic_hexadecimal___globals);
+        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "decode_hex", 32, CPyStatic_hexadecimal___globals);
         goto CPyL15;
     }
     CPy_Unreachable();
 CPyL6: ;
     cpy_r_r11 = CPyDef_hexadecimal___remove_0x_prefix(cpy_r_value);
     if (unlikely(cpy_r_r11 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "decode_hex", 31, CPyStatic_hexadecimal___globals);
+        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "decode_hex", 33, CPyStatic_hexadecimal___globals);
         goto CPyL15;
     }
-    cpy_r_r12 = CPyStatics[237]; /* 'ascii' */
-    cpy_r_r13 = CPyStatics[238]; /* 'encode' */
+    cpy_r_r12 = CPyStatics[238]; /* 'ascii' */
+    cpy_r_r13 = CPyStatics[239]; /* 'encode' */
     PyObject *cpy_r_r14[2] = {cpy_r_r11, cpy_r_r12};
     cpy_r_r15 = (PyObject **)&cpy_r_r14;
     cpy_r_r16 = PyObject_VectorcallMethod(cpy_r_r13, cpy_r_r15, 9223372036854775810ULL, 0);
     if (unlikely(cpy_r_r16 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "decode_hex", 33, CPyStatic_hexadecimal___globals);
+        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "decode_hex", 35, CPyStatic_hexadecimal___globals);
         goto CPyL16;
     }
     CPy_DECREF(cpy_r_r11);
     if (likely(PyBytes_Check(cpy_r_r16) || PyByteArray_Check(cpy_r_r16)))
         cpy_r_r17 = cpy_r_r16;
     else {
-        CPy_TypeErrorTraceback("faster_eth_utils/hexadecimal.py", "decode_hex", 33, CPyStatic_hexadecimal___globals, "bytes", cpy_r_r16);
+        CPy_TypeErrorTraceback("faster_eth_utils/hexadecimal.py", "decode_hex", 35, CPyStatic_hexadecimal___globals, "bytes", cpy_r_r16);
         goto CPyL15;
     }
     cpy_r_r18 = CPyStatic_hexadecimal___unhexlify;
@@ -20968,7 +20983,7 @@ CPyL10: ;
     PyErr_SetString(PyExc_NameError, "value for final name \"unhexlify\" was not set");
     cpy_r_r19 = 0;
     if (unlikely(!cpy_r_r19)) {
-        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "decode_hex", 34, CPyStatic_hexadecimal___globals);
+        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "decode_hex", 36, CPyStatic_hexadecimal___globals);
         goto CPyL15;
     }
     CPy_Unreachable();
@@ -20977,14 +20992,14 @@ CPyL12: ;
     cpy_r_r21 = (PyObject **)&cpy_r_r20;
     cpy_r_r22 = PyObject_Vectorcall(cpy_r_r18, cpy_r_r21, 1, 0);
     if (unlikely(cpy_r_r22 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "decode_hex", 34, CPyStatic_hexadecimal___globals);
+        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "decode_hex", 36, CPyStatic_hexadecimal___globals);
         goto CPyL18;
     }
     CPy_DECREF(cpy_r_r17);
     if (likely(PyBytes_Check(cpy_r_r22) || PyByteArray_Check(cpy_r_r22)))
         cpy_r_r23 = cpy_r_r22;
     else {
-        CPy_TypeErrorTraceback("faster_eth_utils/hexadecimal.py", "decode_hex", 34, CPyStatic_hexadecimal___globals, "bytes", cpy_r_r22);
+        CPy_TypeErrorTraceback("faster_eth_utils/hexadecimal.py", "decode_hex", 36, CPyStatic_hexadecimal___globals, "bytes", cpy_r_r22);
         goto CPyL15;
     }
     return cpy_r_r23;
@@ -21019,7 +21034,7 @@ PyObject *CPyPy_hexadecimal___decode_hex(PyObject *self, PyObject *const *args, 
     PyObject *retval = CPyDef_hexadecimal___decode_hex(arg_value);
     return retval;
 fail: ;
-    CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "decode_hex", 28, CPyStatic_hexadecimal___globals);
+    CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "decode_hex", 30, CPyStatic_hexadecimal___globals);
     return NULL;
 }
 
@@ -21054,16 +21069,16 @@ PyObject *CPyDef_hexadecimal___encode_hex(PyObject *cpy_r_value) {
     PyObject *cpy_r_r28;
     cpy_r_r0 = CPyDef_types___is_string(cpy_r_value);
     if (unlikely(cpy_r_r0 == 2)) {
-        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "encode_hex", 38, CPyStatic_hexadecimal___globals);
+        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "encode_hex", 40, CPyStatic_hexadecimal___globals);
         goto CPyL21;
     }
     if (cpy_r_r0) goto CPyL6;
-    cpy_r_r1 = CPyStatics[239]; /* 'Value must be an instance of str or unicode' */
+    cpy_r_r1 = CPyStatics[240]; /* 'Value must be an instance of str or unicode' */
     cpy_r_r2 = CPyModule_builtins;
     cpy_r_r3 = CPyStatics[16]; /* 'TypeError' */
     cpy_r_r4 = CPyObject_GetAttr(cpy_r_r2, cpy_r_r3);
     if (unlikely(cpy_r_r4 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "encode_hex", 39, CPyStatic_hexadecimal___globals);
+        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "encode_hex", 41, CPyStatic_hexadecimal___globals);
         goto CPyL21;
     }
     PyObject *cpy_r_r5[1] = {cpy_r_r1};
@@ -21071,23 +21086,23 @@ PyObject *CPyDef_hexadecimal___encode_hex(PyObject *cpy_r_value) {
     cpy_r_r7 = PyObject_Vectorcall(cpy_r_r4, cpy_r_r6, 1, 0);
     CPy_DECREF(cpy_r_r4);
     if (unlikely(cpy_r_r7 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "encode_hex", 39, CPyStatic_hexadecimal___globals);
+        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "encode_hex", 41, CPyStatic_hexadecimal___globals);
         goto CPyL21;
     }
     CPy_Raise(cpy_r_r7);
     CPy_DECREF(cpy_r_r7);
     if (unlikely(!0)) {
-        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "encode_hex", 39, CPyStatic_hexadecimal___globals);
+        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "encode_hex", 41, CPyStatic_hexadecimal___globals);
         goto CPyL21;
     }
     CPy_Unreachable();
 CPyL6: ;
     cpy_r_r8 = (PyObject *)&PyBytes_Type;
     cpy_r_r9 = CPyModule_builtins;
-    cpy_r_r10 = CPyStatics[130]; /* 'bytearray' */
+    cpy_r_r10 = CPyStatics[131]; /* 'bytearray' */
     cpy_r_r11 = CPyObject_GetAttr(cpy_r_r9, cpy_r_r10);
     if (unlikely(cpy_r_r11 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "encode_hex", 40, CPyStatic_hexadecimal___globals);
+        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "encode_hex", 42, CPyStatic_hexadecimal___globals);
         goto CPyL21;
     }
     CPy_INCREF(cpy_r_r8);
@@ -21104,7 +21119,7 @@ CPyL6: ;
     CPy_DECREF(cpy_r_r13);
     cpy_r_r15 = cpy_r_r14 >= 0;
     if (unlikely(!cpy_r_r15)) {
-        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "encode_hex", 40, CPyStatic_hexadecimal___globals);
+        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "encode_hex", 42, CPyStatic_hexadecimal___globals);
         goto CPyL21;
     }
     cpy_r_r16 = cpy_r_r14;
@@ -21117,13 +21132,13 @@ CPyL10: ;
     if (likely(PyUnicode_Check(cpy_r_value)))
         cpy_r_r17 = cpy_r_value;
     else {
-        CPy_TypeErrorTraceback("faster_eth_utils/hexadecimal.py", "encode_hex", 43, CPyStatic_hexadecimal___globals, "str", cpy_r_value);
+        CPy_TypeErrorTraceback("faster_eth_utils/hexadecimal.py", "encode_hex", 45, CPyStatic_hexadecimal___globals, "str", cpy_r_value);
         goto CPyL21;
     }
     cpy_r_r18 = PyUnicode_AsASCIIString(cpy_r_r17);
     CPy_DECREF(cpy_r_r17);
     if (unlikely(cpy_r_r18 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "encode_hex", 43, CPyStatic_hexadecimal___globals);
+        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "encode_hex", 45, CPyStatic_hexadecimal___globals);
         goto CPyL21;
     }
     cpy_r_ascii_bytes = cpy_r_r18;
@@ -21137,7 +21152,7 @@ CPyL14: ;
     PyErr_SetString(PyExc_NameError, "value for final name \"hexlify\" was not set");
     cpy_r_r20 = 0;
     if (unlikely(!cpy_r_r20)) {
-        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "encode_hex", 45, CPyStatic_hexadecimal___globals);
+        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "encode_hex", 47, CPyStatic_hexadecimal___globals);
         goto CPyL21;
     }
     CPy_Unreachable();
@@ -21146,27 +21161,27 @@ CPyL16: ;
     cpy_r_r22 = (PyObject **)&cpy_r_r21;
     cpy_r_r23 = PyObject_Vectorcall(cpy_r_r19, cpy_r_r22, 1, 0);
     if (unlikely(cpy_r_r23 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "encode_hex", 45, CPyStatic_hexadecimal___globals);
+        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "encode_hex", 47, CPyStatic_hexadecimal___globals);
         goto CPyL23;
     }
     CPy_DECREF(cpy_r_ascii_bytes);
     if (likely(PyBytes_Check(cpy_r_r23) || PyByteArray_Check(cpy_r_r23)))
         cpy_r_r24 = cpy_r_r23;
     else {
-        CPy_TypeErrorTraceback("faster_eth_utils/hexadecimal.py", "encode_hex", 45, CPyStatic_hexadecimal___globals, "bytes", cpy_r_r23);
+        CPy_TypeErrorTraceback("faster_eth_utils/hexadecimal.py", "encode_hex", 47, CPyStatic_hexadecimal___globals, "bytes", cpy_r_r23);
         goto CPyL21;
     }
-    cpy_r_r25 = CPyStatics[237]; /* 'ascii' */
+    cpy_r_r25 = CPyStatics[238]; /* 'ascii' */
     cpy_r_r26 = CPy_Decode(cpy_r_r24, cpy_r_r25, NULL);
     CPy_DECREF(cpy_r_r24);
     if (unlikely(cpy_r_r26 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "encode_hex", 46, CPyStatic_hexadecimal___globals);
+        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "encode_hex", 48, CPyStatic_hexadecimal___globals);
         goto CPyL21;
     }
     cpy_r_r27 = CPyDef_hexadecimal___add_0x_prefix(cpy_r_r26);
     CPy_DECREF(cpy_r_r26);
     if (unlikely(cpy_r_r27 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "encode_hex", 46, CPyStatic_hexadecimal___globals);
+        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "encode_hex", 48, CPyStatic_hexadecimal___globals);
         goto CPyL21;
     }
     return cpy_r_r27;
@@ -21192,7 +21207,7 @@ PyObject *CPyPy_hexadecimal___encode_hex(PyObject *self, PyObject *const *args, 
     PyObject *retval = CPyDef_hexadecimal___encode_hex(arg_value);
     return retval;
 fail: ;
-    CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "encode_hex", 37, CPyStatic_hexadecimal___globals);
+    CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "encode_hex", 39, CPyStatic_hexadecimal___globals);
     return NULL;
 }
 
@@ -21203,8 +21218,8 @@ char CPyDef_hexadecimal___is_0x_prefixed(PyObject *cpy_r_value) {
     PyObject *cpy_r_r3;
     char cpy_r_r4;
     char cpy_r_r5;
-    cpy_r_r0 = CPyStatics[240]; /* '0x' */
-    cpy_r_r1 = CPyStatics[241]; /* '0X' */
+    cpy_r_r0 = CPyStatics[241]; /* '0x' */
+    cpy_r_r1 = CPyStatics[242]; /* '0X' */
     CPy_INCREF(cpy_r_r0);
     CPy_INCREF(cpy_r_r1);
     cpy_r_r2.f0 = cpy_r_r0;
@@ -21219,7 +21234,7 @@ char CPyDef_hexadecimal___is_0x_prefixed(PyObject *cpy_r_value) {
     cpy_r_r4 = CPyStr_Startswith(cpy_r_value, cpy_r_r3);
     CPy_DECREF(cpy_r_r3);
     if (unlikely(cpy_r_r4 == 2)) {
-        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "is_0x_prefixed", 55, CPyStatic_hexadecimal___globals);
+        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "is_0x_prefixed", 57, CPyStatic_hexadecimal___globals);
         goto CPyL2;
     }
     return cpy_r_r4;
@@ -21250,7 +21265,7 @@ PyObject *CPyPy_hexadecimal___is_0x_prefixed(PyObject *self, PyObject *const *ar
     CPy_INCREF(retbox);
     return retbox;
 fail: ;
-    CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "is_0x_prefixed", 49, CPyStatic_hexadecimal___globals);
+    CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "is_0x_prefixed", 51, CPyStatic_hexadecimal___globals);
     return NULL;
 }
 
@@ -21268,34 +21283,34 @@ PyObject *CPyDef_hexadecimal___remove_0x_prefix(PyObject *cpy_r_value) {
     if (likely(PyUnicode_Check(cpy_r_value)))
         cpy_r_r0 = cpy_r_value;
     else {
-        CPy_TypeErrorTraceback("faster_eth_utils/hexadecimal.py", "remove_0x_prefix", 59, CPyStatic_hexadecimal___globals, "str", cpy_r_value);
+        CPy_TypeErrorTraceback("faster_eth_utils/hexadecimal.py", "remove_0x_prefix", 61, CPyStatic_hexadecimal___globals, "str", cpy_r_value);
         goto CPyL8;
     }
     cpy_r_r1 = CPyDef_hexadecimal___is_0x_prefixed(cpy_r_r0);
     CPy_DECREF(cpy_r_r0);
     if (unlikely(cpy_r_r1 == 2)) {
-        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "remove_0x_prefix", 59, CPyStatic_hexadecimal___globals);
+        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "remove_0x_prefix", 61, CPyStatic_hexadecimal___globals);
         goto CPyL8;
     }
     if (!cpy_r_r1) goto CPyL7;
     cpy_r_r2 = (PyObject *)&_Py_NoneStruct;
     cpy_r_r3 = (PyObject *)&_Py_NoneStruct;
-    cpy_r_r4 = CPyStatics[320]; /* 2 */
+    cpy_r_r4 = CPyStatics[321]; /* 2 */
     cpy_r_r5 = PySlice_New(cpy_r_r4, cpy_r_r2, cpy_r_r3);
     if (unlikely(cpy_r_r5 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "remove_0x_prefix", 60, CPyStatic_hexadecimal___globals);
+        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "remove_0x_prefix", 62, CPyStatic_hexadecimal___globals);
         goto CPyL8;
     }
     cpy_r_r6 = PyObject_GetItem(cpy_r_value, cpy_r_r5);
     CPy_DECREF(cpy_r_r5);
     if (unlikely(cpy_r_r6 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "remove_0x_prefix", 60, CPyStatic_hexadecimal___globals);
+        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "remove_0x_prefix", 62, CPyStatic_hexadecimal___globals);
         goto CPyL8;
     }
     if (likely(PyUnicode_Check(cpy_r_r6)))
         cpy_r_r7 = cpy_r_r6;
     else {
-        CPy_TypeErrorTraceback("faster_eth_utils/hexadecimal.py", "remove_0x_prefix", 60, CPyStatic_hexadecimal___globals, "str", cpy_r_r6);
+        CPy_TypeErrorTraceback("faster_eth_utils/hexadecimal.py", "remove_0x_prefix", 62, CPyStatic_hexadecimal___globals, "str", cpy_r_r6);
         goto CPyL8;
     }
     return cpy_r_r7;
@@ -21318,7 +21333,7 @@ PyObject *CPyPy_hexadecimal___remove_0x_prefix(PyObject *self, PyObject *const *
     PyObject *retval = CPyDef_hexadecimal___remove_0x_prefix(arg_value);
     return retval;
 fail: ;
-    CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "remove_0x_prefix", 58, CPyStatic_hexadecimal___globals);
+    CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "remove_0x_prefix", 60, CPyStatic_hexadecimal___globals);
     return NULL;
 }
 
@@ -21333,29 +21348,29 @@ PyObject *CPyDef_hexadecimal___add_0x_prefix(PyObject *cpy_r_value) {
     if (likely(PyUnicode_Check(cpy_r_value)))
         cpy_r_r0 = cpy_r_value;
     else {
-        CPy_TypeErrorTraceback("faster_eth_utils/hexadecimal.py", "add_0x_prefix", 65, CPyStatic_hexadecimal___globals, "str", cpy_r_value);
+        CPy_TypeErrorTraceback("faster_eth_utils/hexadecimal.py", "add_0x_prefix", 67, CPyStatic_hexadecimal___globals, "str", cpy_r_value);
         goto CPyL7;
     }
     cpy_r_r1 = CPyDef_hexadecimal___is_0x_prefixed(cpy_r_r0);
     CPy_DECREF(cpy_r_r0);
     if (unlikely(cpy_r_r1 == 2)) {
-        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "add_0x_prefix", 65, CPyStatic_hexadecimal___globals);
+        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "add_0x_prefix", 67, CPyStatic_hexadecimal___globals);
         goto CPyL7;
     }
     if (!cpy_r_r1) goto CPyL4;
     CPy_INCREF(cpy_r_value);
     return cpy_r_value;
 CPyL4: ;
-    cpy_r_r2 = CPyStatics[240]; /* '0x' */
+    cpy_r_r2 = CPyStatics[241]; /* '0x' */
     cpy_r_r3 = PyNumber_Add(cpy_r_r2, cpy_r_value);
     if (unlikely(cpy_r_r3 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "add_0x_prefix", 67, CPyStatic_hexadecimal___globals);
+        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "add_0x_prefix", 69, CPyStatic_hexadecimal___globals);
         goto CPyL7;
     }
     if (likely(PyUnicode_Check(cpy_r_r3)))
         cpy_r_r4 = cpy_r_r3;
     else {
-        CPy_TypeErrorTraceback("faster_eth_utils/hexadecimal.py", "add_0x_prefix", 67, CPyStatic_hexadecimal___globals, "str", cpy_r_r3);
+        CPy_TypeErrorTraceback("faster_eth_utils/hexadecimal.py", "add_0x_prefix", 69, CPyStatic_hexadecimal___globals, "str", cpy_r_r3);
         goto CPyL7;
     }
     return cpy_r_r4;
@@ -21375,7 +21390,7 @@ PyObject *CPyPy_hexadecimal___add_0x_prefix(PyObject *self, PyObject *const *arg
     PyObject *retval = CPyDef_hexadecimal___add_0x_prefix(arg_value);
     return retval;
 fail: ;
-    CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "add_0x_prefix", 64, CPyStatic_hexadecimal___globals);
+    CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "add_0x_prefix", 66, CPyStatic_hexadecimal___globals);
     return NULL;
 }
 
@@ -21398,7 +21413,7 @@ char CPyDef_hexadecimal___is_hexstr(PyObject *cpy_r_value) {
     cpy_r_r1 = PyObject_IsInstance(cpy_r_value, cpy_r_r0);
     cpy_r_r2 = cpy_r_r1 >= 0;
     if (unlikely(!cpy_r_r2)) {
-        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "is_hexstr", 71, CPyStatic_hexadecimal___globals);
+        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "is_hexstr", 73, CPyStatic_hexadecimal___globals);
         goto CPyL11;
     }
     cpy_r_r3 = cpy_r_r1;
@@ -21407,7 +21422,7 @@ char CPyDef_hexadecimal___is_hexstr(PyObject *cpy_r_value) {
     if (likely(PyUnicode_Check(cpy_r_value)))
         cpy_r_r4 = cpy_r_value;
     else {
-        CPy_TypeErrorTraceback("faster_eth_utils/hexadecimal.py", "is_hexstr", 71, CPyStatic_hexadecimal___globals, "str", cpy_r_value);
+        CPy_TypeErrorTraceback("faster_eth_utils/hexadecimal.py", "is_hexstr", 73, CPyStatic_hexadecimal___globals, "str", cpy_r_value);
         goto CPyL11;
     }
     cpy_r_r5 = CPyStr_IsTrue(cpy_r_r4);
@@ -21420,7 +21435,7 @@ CPyL5: ;
     if (likely(PyUnicode_Check(cpy_r_value)))
         cpy_r_r6 = cpy_r_value;
     else {
-        CPy_TypeErrorTraceback("faster_eth_utils/hexadecimal.py", "is_hexstr", 73, CPyStatic_hexadecimal___globals, "str", cpy_r_value);
+        CPy_TypeErrorTraceback("faster_eth_utils/hexadecimal.py", "is_hexstr", 75, CPyStatic_hexadecimal___globals, "str", cpy_r_value);
         goto CPyL11;
     }
     cpy_r_r7 = CPyStatic_hexadecimal____HEX_REGEXP_MATCH;
@@ -21432,7 +21447,7 @@ CPyL7: ;
     PyErr_SetString(PyExc_NameError, "value for final name \"_HEX_REGEXP_MATCH\" was not set");
     cpy_r_r8 = 0;
     if (unlikely(!cpy_r_r8)) {
-        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "is_hexstr", 73, CPyStatic_hexadecimal___globals);
+        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "is_hexstr", 75, CPyStatic_hexadecimal___globals);
         goto CPyL11;
     }
     CPy_Unreachable();
@@ -21441,7 +21456,7 @@ CPyL9: ;
     cpy_r_r10 = (PyObject **)&cpy_r_r9;
     cpy_r_r11 = PyObject_Vectorcall(cpy_r_r7, cpy_r_r10, 1, 0);
     if (unlikely(cpy_r_r11 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "is_hexstr", 73, CPyStatic_hexadecimal___globals);
+        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "is_hexstr", 75, CPyStatic_hexadecimal___globals);
         goto CPyL13;
     }
     CPy_DECREF(cpy_r_r6);
@@ -21476,7 +21491,7 @@ PyObject *CPyPy_hexadecimal___is_hexstr(PyObject *self, PyObject *const *args, s
     CPy_INCREF(retbox);
     return retbox;
 fail: ;
-    CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "is_hexstr", 70, CPyStatic_hexadecimal___globals);
+    CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "is_hexstr", 72, CPyStatic_hexadecimal___globals);
     return NULL;
 }
 
@@ -21507,28 +21522,28 @@ char CPyDef_hexadecimal___is_hex(PyObject *cpy_r_value) {
     cpy_r_r1 = PyObject_IsInstance(cpy_r_value, cpy_r_r0);
     cpy_r_r2 = cpy_r_r1 >= 0;
     if (unlikely(!cpy_r_r2)) {
-        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "is_hex", 77, CPyStatic_hexadecimal___globals);
+        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "is_hex", 79, CPyStatic_hexadecimal___globals);
         goto CPyL17;
     }
     cpy_r_r3 = cpy_r_r1;
     if (cpy_r_r3) goto CPyL8;
-    cpy_r_r4 = CPyStatics[242]; /* 'is_hex requires text typed arguments. Got: ' */
+    cpy_r_r4 = CPyStatics[243]; /* 'is_hex requires text typed arguments. Got: ' */
     cpy_r_r5 = PyObject_Repr(cpy_r_value);
     if (unlikely(cpy_r_r5 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "is_hex", 78, CPyStatic_hexadecimal___globals);
+        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "is_hex", 80, CPyStatic_hexadecimal___globals);
         goto CPyL17;
     }
     cpy_r_r6 = CPyStr_Build(2, cpy_r_r4, cpy_r_r5);
     CPy_DECREF(cpy_r_r5);
     if (unlikely(cpy_r_r6 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "is_hex", 78, CPyStatic_hexadecimal___globals);
+        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "is_hex", 80, CPyStatic_hexadecimal___globals);
         goto CPyL17;
     }
     cpy_r_r7 = CPyModule_builtins;
     cpy_r_r8 = CPyStatics[16]; /* 'TypeError' */
     cpy_r_r9 = CPyObject_GetAttr(cpy_r_r7, cpy_r_r8);
     if (unlikely(cpy_r_r9 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "is_hex", 78, CPyStatic_hexadecimal___globals);
+        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "is_hex", 80, CPyStatic_hexadecimal___globals);
         goto CPyL18;
     }
     PyObject *cpy_r_r10[1] = {cpy_r_r6};
@@ -21536,14 +21551,14 @@ char CPyDef_hexadecimal___is_hex(PyObject *cpy_r_value) {
     cpy_r_r12 = PyObject_Vectorcall(cpy_r_r9, cpy_r_r11, 1, 0);
     CPy_DECREF(cpy_r_r9);
     if (unlikely(cpy_r_r12 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "is_hex", 78, CPyStatic_hexadecimal___globals);
+        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "is_hex", 80, CPyStatic_hexadecimal___globals);
         goto CPyL18;
     }
     CPy_DECREF(cpy_r_r6);
     CPy_Raise(cpy_r_r12);
     CPy_DECREF(cpy_r_r12);
     if (unlikely(!0)) {
-        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "is_hex", 78, CPyStatic_hexadecimal___globals);
+        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "is_hex", 80, CPyStatic_hexadecimal___globals);
         goto CPyL17;
     }
     CPy_Unreachable();
@@ -21552,7 +21567,7 @@ CPyL8: ;
     if (likely(PyUnicode_Check(cpy_r_value)))
         cpy_r_r13 = cpy_r_value;
     else {
-        CPy_TypeErrorTraceback("faster_eth_utils/hexadecimal.py", "is_hex", 79, CPyStatic_hexadecimal___globals, "str", cpy_r_value);
+        CPy_TypeErrorTraceback("faster_eth_utils/hexadecimal.py", "is_hex", 81, CPyStatic_hexadecimal___globals, "str", cpy_r_value);
         goto CPyL17;
     }
     cpy_r_r14 = CPyStr_IsTrue(cpy_r_r13);
@@ -21564,7 +21579,7 @@ CPyL11: ;
     if (likely(PyUnicode_Check(cpy_r_value)))
         cpy_r_r15 = cpy_r_value;
     else {
-        CPy_TypeErrorTraceback("faster_eth_utils/hexadecimal.py", "is_hex", 81, CPyStatic_hexadecimal___globals, "str", cpy_r_value);
+        CPy_TypeErrorTraceback("faster_eth_utils/hexadecimal.py", "is_hex", 83, CPyStatic_hexadecimal___globals, "str", cpy_r_value);
         goto CPyL17;
     }
     cpy_r_r16 = CPyStatic_hexadecimal____HEX_REGEXP_MATCH;
@@ -21576,7 +21591,7 @@ CPyL13: ;
     PyErr_SetString(PyExc_NameError, "value for final name \"_HEX_REGEXP_MATCH\" was not set");
     cpy_r_r17 = 0;
     if (unlikely(!cpy_r_r17)) {
-        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "is_hex", 81, CPyStatic_hexadecimal___globals);
+        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "is_hex", 83, CPyStatic_hexadecimal___globals);
         goto CPyL17;
     }
     CPy_Unreachable();
@@ -21585,7 +21600,7 @@ CPyL15: ;
     cpy_r_r19 = (PyObject **)&cpy_r_r18;
     cpy_r_r20 = PyObject_Vectorcall(cpy_r_r16, cpy_r_r19, 1, 0);
     if (unlikely(cpy_r_r20 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "is_hex", 81, CPyStatic_hexadecimal___globals);
+        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "is_hex", 83, CPyStatic_hexadecimal___globals);
         goto CPyL20;
     }
     CPy_DECREF(cpy_r_r15);
@@ -21623,7 +21638,7 @@ PyObject *CPyPy_hexadecimal___is_hex(PyObject *self, PyObject *const *args, size
     CPy_INCREF(retbox);
     return retbox;
 fail: ;
-    CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "is_hex", 76, CPyStatic_hexadecimal___globals);
+    CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "is_hex", 78, CPyStatic_hexadecimal___globals);
     return NULL;
 }
 
@@ -21658,29 +21673,33 @@ char CPyDef_hexadecimal_____top_level__(void) {
     PyObject *cpy_r_r29;
     PyObject *cpy_r_r30;
     PyObject *cpy_r_r31;
-    PyObject **cpy_r_r33;
+    PyObject *cpy_r_r32;
+    PyObject *cpy_r_r33;
     PyObject *cpy_r_r34;
     PyObject *cpy_r_r35;
-    PyObject *cpy_r_r36;
-    PyObject *cpy_r_r37;
+    PyObject **cpy_r_r37;
     PyObject *cpy_r_r38;
-    int32_t cpy_r_r39;
-    char cpy_r_r40;
+    PyObject *cpy_r_r39;
+    PyObject *cpy_r_r40;
     PyObject *cpy_r_r41;
     PyObject *cpy_r_r42;
-    PyObject *cpy_r_r43;
-    PyObject *cpy_r_r44;
+    int32_t cpy_r_r43;
+    char cpy_r_r44;
     PyObject *cpy_r_r45;
-    int32_t cpy_r_r46;
-    char cpy_r_r47;
+    PyObject *cpy_r_r46;
+    PyObject *cpy_r_r47;
     PyObject *cpy_r_r48;
     PyObject *cpy_r_r49;
-    PyObject *cpy_r_r50;
-    PyObject *cpy_r_r51;
+    int32_t cpy_r_r50;
+    char cpy_r_r51;
     PyObject *cpy_r_r52;
-    int32_t cpy_r_r53;
-    char cpy_r_r54;
-    char cpy_r_r55;
+    PyObject *cpy_r_r53;
+    PyObject *cpy_r_r54;
+    PyObject *cpy_r_r55;
+    PyObject *cpy_r_r56;
+    int32_t cpy_r_r57;
+    char cpy_r_r58;
+    char cpy_r_r59;
     cpy_r_r0 = CPyModule_builtins;
     cpy_r_r1 = (PyObject *)&_Py_NoneStruct;
     cpy_r_r2 = cpy_r_r0 != cpy_r_r1;
@@ -21689,7 +21708,7 @@ char CPyDef_hexadecimal_____top_level__(void) {
     cpy_r_r4 = PyImport_Import(cpy_r_r3);
     if (unlikely(cpy_r_r4 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "<module>", -1, CPyStatic_hexadecimal___globals);
-        goto CPyL16;
+        goto CPyL17;
     }
     CPyModule_builtins = cpy_r_r4;
     CPy_INCREF(CPyModule_builtins);
@@ -21701,119 +21720,130 @@ CPyL3: ;
     cpy_r_r8 = (void *)&cpy_r_r7;
     int64_t cpy_r_r9[2] = {3, 4};
     cpy_r_r10 = (void *)&cpy_r_r9;
-    cpy_r_r11 = CPyStatics[377]; /* (('binascii', 'binascii', 'binascii'), ('re', 're', 're')) */
+    cpy_r_r11 = CPyStatics[379]; /* (('binascii', 'binascii', 'binascii'), ('re', 're', 're')) */
     cpy_r_r12 = CPyStatic_hexadecimal___globals;
-    cpy_r_r13 = CPyStatics[244]; /* 'faster_eth_utils/hexadecimal.py' */
+    cpy_r_r13 = CPyStatics[245]; /* 'faster_eth_utils/hexadecimal.py' */
     cpy_r_r14 = CPyStatics[70]; /* '<module>' */
     cpy_r_r15 = CPyImport_ImportMany(cpy_r_r11, cpy_r_r8, cpy_r_r12, cpy_r_r13, cpy_r_r14, cpy_r_r10);
-    if (!cpy_r_r15) goto CPyL16;
-    cpy_r_r16 = CPyStatics[378]; /* ('Any', 'AnyStr', 'Final', 'TypeGuard') */
+    if (!cpy_r_r15) goto CPyL17;
+    cpy_r_r16 = CPyStatics[380]; /* ('Any', 'AnyStr', 'Final') */
     cpy_r_r17 = CPyStatics[81]; /* 'typing' */
     cpy_r_r18 = CPyStatic_hexadecimal___globals;
     cpy_r_r19 = CPyImport_ImportFromMany(cpy_r_r17, cpy_r_r16, cpy_r_r16, cpy_r_r18);
     if (unlikely(cpy_r_r19 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "<module>", 5, CPyStatic_hexadecimal___globals);
-        goto CPyL16;
+        goto CPyL17;
     }
     CPyModule_typing = cpy_r_r19;
     CPy_INCREF(CPyModule_typing);
     CPy_DECREF(cpy_r_r19);
-    cpy_r_r20 = CPyStatics[379]; /* ('HexStr',) */
+    cpy_r_r20 = CPyStatics[381]; /* ('HexStr',) */
     cpy_r_r21 = CPyStatics[91]; /* 'eth_typing' */
     cpy_r_r22 = CPyStatic_hexadecimal___globals;
     cpy_r_r23 = CPyImport_ImportFromMany(cpy_r_r21, cpy_r_r20, cpy_r_r20, cpy_r_r22);
     if (unlikely(cpy_r_r23 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "<module>", 12, CPyStatic_hexadecimal___globals);
-        goto CPyL16;
+        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "<module>", 11, CPyStatic_hexadecimal___globals);
+        goto CPyL17;
     }
     CPyModule_eth_typing = cpy_r_r23;
     CPy_INCREF(CPyModule_eth_typing);
     CPy_DECREF(cpy_r_r23);
-    cpy_r_r24 = CPyStatics[380]; /* ('is_string', 'is_text') */
-    cpy_r_r25 = CPyStatics[93]; /* 'faster_eth_utils.types' */
+    cpy_r_r24 = CPyStatics[350]; /* ('TypeGuard',) */
+    cpy_r_r25 = CPyStatics[115]; /* 'typing_extensions' */
     cpy_r_r26 = CPyStatic_hexadecimal___globals;
     cpy_r_r27 = CPyImport_ImportFromMany(cpy_r_r25, cpy_r_r24, cpy_r_r24, cpy_r_r26);
     if (unlikely(cpy_r_r27 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "<module>", 16, CPyStatic_hexadecimal___globals);
-        goto CPyL16;
+        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "<module>", 14, CPyStatic_hexadecimal___globals);
+        goto CPyL17;
     }
-    CPyModule_faster_eth_utils___types = cpy_r_r27;
-    CPy_INCREF(CPyModule_faster_eth_utils___types);
+    CPyModule_typing_extensions = cpy_r_r27;
+    CPy_INCREF(CPyModule_typing_extensions);
     CPy_DECREF(cpy_r_r27);
-    cpy_r_r28 = CPyStatics[246]; /* '(0[xX])?[0-9a-fA-F]*' */
-    cpy_r_r29 = CPyModule_re;
-    cpy_r_r30 = CPyStatics[18]; /* 'compile' */
-    cpy_r_r31 = CPyObject_GetAttr(cpy_r_r29, cpy_r_r30);
+    cpy_r_r28 = CPyStatics[382]; /* ('is_string', 'is_text') */
+    cpy_r_r29 = CPyStatics[93]; /* 'faster_eth_utils.types' */
+    cpy_r_r30 = CPyStatic_hexadecimal___globals;
+    cpy_r_r31 = CPyImport_ImportFromMany(cpy_r_r29, cpy_r_r28, cpy_r_r28, cpy_r_r30);
     if (unlikely(cpy_r_r31 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "<module>", 21, CPyStatic_hexadecimal___globals);
-        goto CPyL16;
+        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "<module>", 18, CPyStatic_hexadecimal___globals);
+        goto CPyL17;
     }
-    PyObject *cpy_r_r32[1] = {cpy_r_r28};
-    cpy_r_r33 = (PyObject **)&cpy_r_r32;
-    cpy_r_r34 = PyObject_Vectorcall(cpy_r_r31, cpy_r_r33, 1, 0);
+    CPyModule_faster_eth_utils___types = cpy_r_r31;
+    CPy_INCREF(CPyModule_faster_eth_utils___types);
     CPy_DECREF(cpy_r_r31);
-    if (unlikely(cpy_r_r34 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "<module>", 21, CPyStatic_hexadecimal___globals);
-        goto CPyL16;
+    cpy_r_r32 = CPyStatics[247]; /* '(0[xX])?[0-9a-fA-F]*' */
+    cpy_r_r33 = CPyModule_re;
+    cpy_r_r34 = CPyStatics[18]; /* 'compile' */
+    cpy_r_r35 = CPyObject_GetAttr(cpy_r_r33, cpy_r_r34);
+    if (unlikely(cpy_r_r35 == NULL)) {
+        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "<module>", 23, CPyStatic_hexadecimal___globals);
+        goto CPyL17;
     }
-    cpy_r_r35 = CPyStatics[95]; /* 'fullmatch' */
-    cpy_r_r36 = CPyObject_GetAttr(cpy_r_r34, cpy_r_r35);
-    CPy_DECREF(cpy_r_r34);
-    if (unlikely(cpy_r_r36 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "<module>", 21, CPyStatic_hexadecimal___globals);
-        goto CPyL16;
+    PyObject *cpy_r_r36[1] = {cpy_r_r32};
+    cpy_r_r37 = (PyObject **)&cpy_r_r36;
+    cpy_r_r38 = PyObject_Vectorcall(cpy_r_r35, cpy_r_r37, 1, 0);
+    CPy_DECREF(cpy_r_r35);
+    if (unlikely(cpy_r_r38 == NULL)) {
+        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "<module>", 23, CPyStatic_hexadecimal___globals);
+        goto CPyL17;
     }
-    CPyStatic_hexadecimal____HEX_REGEXP_MATCH = cpy_r_r36;
+    cpy_r_r39 = CPyStatics[95]; /* 'fullmatch' */
+    cpy_r_r40 = CPyObject_GetAttr(cpy_r_r38, cpy_r_r39);
+    CPy_DECREF(cpy_r_r38);
+    if (unlikely(cpy_r_r40 == NULL)) {
+        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "<module>", 23, CPyStatic_hexadecimal___globals);
+        goto CPyL17;
+    }
+    CPyStatic_hexadecimal____HEX_REGEXP_MATCH = cpy_r_r40;
     CPy_INCREF(CPyStatic_hexadecimal____HEX_REGEXP_MATCH);
-    cpy_r_r37 = CPyStatic_hexadecimal___globals;
-    cpy_r_r38 = CPyStatics[247]; /* '_HEX_REGEXP_MATCH' */
-    cpy_r_r39 = CPyDict_SetItem(cpy_r_r37, cpy_r_r38, cpy_r_r36);
-    CPy_DECREF(cpy_r_r36);
-    cpy_r_r40 = cpy_r_r39 >= 0;
-    if (unlikely(!cpy_r_r40)) {
-        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "<module>", 21, CPyStatic_hexadecimal___globals);
-        goto CPyL16;
-    }
-    cpy_r_r41 = CPyModule_binascii;
-    cpy_r_r42 = CPyStatics[248]; /* 'hexlify' */
-    cpy_r_r43 = CPyObject_GetAttr(cpy_r_r41, cpy_r_r42);
-    if (unlikely(cpy_r_r43 == NULL)) {
+    cpy_r_r41 = CPyStatic_hexadecimal___globals;
+    cpy_r_r42 = CPyStatics[248]; /* '_HEX_REGEXP_MATCH' */
+    cpy_r_r43 = CPyDict_SetItem(cpy_r_r41, cpy_r_r42, cpy_r_r40);
+    CPy_DECREF(cpy_r_r40);
+    cpy_r_r44 = cpy_r_r43 >= 0;
+    if (unlikely(!cpy_r_r44)) {
         CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "<module>", 23, CPyStatic_hexadecimal___globals);
-        goto CPyL16;
+        goto CPyL17;
     }
-    CPyStatic_hexadecimal___hexlify = cpy_r_r43;
+    cpy_r_r45 = CPyModule_binascii;
+    cpy_r_r46 = CPyStatics[249]; /* 'hexlify' */
+    cpy_r_r47 = CPyObject_GetAttr(cpy_r_r45, cpy_r_r46);
+    if (unlikely(cpy_r_r47 == NULL)) {
+        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "<module>", 25, CPyStatic_hexadecimal___globals);
+        goto CPyL17;
+    }
+    CPyStatic_hexadecimal___hexlify = cpy_r_r47;
     CPy_INCREF(CPyStatic_hexadecimal___hexlify);
-    cpy_r_r44 = CPyStatic_hexadecimal___globals;
-    cpy_r_r45 = CPyStatics[248]; /* 'hexlify' */
-    cpy_r_r46 = CPyDict_SetItem(cpy_r_r44, cpy_r_r45, cpy_r_r43);
-    CPy_DECREF(cpy_r_r43);
-    cpy_r_r47 = cpy_r_r46 >= 0;
-    if (unlikely(!cpy_r_r47)) {
-        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "<module>", 23, CPyStatic_hexadecimal___globals);
-        goto CPyL16;
+    cpy_r_r48 = CPyStatic_hexadecimal___globals;
+    cpy_r_r49 = CPyStatics[249]; /* 'hexlify' */
+    cpy_r_r50 = CPyDict_SetItem(cpy_r_r48, cpy_r_r49, cpy_r_r47);
+    CPy_DECREF(cpy_r_r47);
+    cpy_r_r51 = cpy_r_r50 >= 0;
+    if (unlikely(!cpy_r_r51)) {
+        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "<module>", 25, CPyStatic_hexadecimal___globals);
+        goto CPyL17;
     }
-    cpy_r_r48 = CPyModule_binascii;
-    cpy_r_r49 = CPyStatics[249]; /* 'unhexlify' */
-    cpy_r_r50 = CPyObject_GetAttr(cpy_r_r48, cpy_r_r49);
-    if (unlikely(cpy_r_r50 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "<module>", 24, CPyStatic_hexadecimal___globals);
-        goto CPyL16;
+    cpy_r_r52 = CPyModule_binascii;
+    cpy_r_r53 = CPyStatics[250]; /* 'unhexlify' */
+    cpy_r_r54 = CPyObject_GetAttr(cpy_r_r52, cpy_r_r53);
+    if (unlikely(cpy_r_r54 == NULL)) {
+        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "<module>", 26, CPyStatic_hexadecimal___globals);
+        goto CPyL17;
     }
-    CPyStatic_hexadecimal___unhexlify = cpy_r_r50;
+    CPyStatic_hexadecimal___unhexlify = cpy_r_r54;
     CPy_INCREF(CPyStatic_hexadecimal___unhexlify);
-    cpy_r_r51 = CPyStatic_hexadecimal___globals;
-    cpy_r_r52 = CPyStatics[249]; /* 'unhexlify' */
-    cpy_r_r53 = CPyDict_SetItem(cpy_r_r51, cpy_r_r52, cpy_r_r50);
-    CPy_DECREF(cpy_r_r50);
-    cpy_r_r54 = cpy_r_r53 >= 0;
-    if (unlikely(!cpy_r_r54)) {
-        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "<module>", 24, CPyStatic_hexadecimal___globals);
-        goto CPyL16;
+    cpy_r_r55 = CPyStatic_hexadecimal___globals;
+    cpy_r_r56 = CPyStatics[250]; /* 'unhexlify' */
+    cpy_r_r57 = CPyDict_SetItem(cpy_r_r55, cpy_r_r56, cpy_r_r54);
+    CPy_DECREF(cpy_r_r54);
+    cpy_r_r58 = cpy_r_r57 >= 0;
+    if (unlikely(!cpy_r_r58)) {
+        CPy_AddTraceback("faster_eth_utils/hexadecimal.py", "<module>", 26, CPyStatic_hexadecimal___globals);
+        goto CPyL17;
     }
     return 1;
-CPyL16: ;
-    cpy_r_r55 = 2;
-    return cpy_r_r55;
+CPyL17: ;
+    cpy_r_r59 = 2;
+    return cpy_r_r59;
 }
 
 static PyObject *humanize____consume_leading_zero_units_env_setup(PyTypeObject *type);
@@ -23010,7 +23040,7 @@ PyObject *CPyDef_humanize___humanize_seconds(PyObject *cpy_r_seconds) {
     cpy_r_r5 = cpy_r_r4 == 0;
     CPyTagged_DECREF(cpy_r_r4);
     if (!cpy_r_r5) goto CPyL4;
-    cpy_r_r6 = CPyStatics[250]; /* '0s' */
+    cpy_r_r6 = CPyStatics[251]; /* '0s' */
     CPy_INCREF(cpy_r_r6);
     return cpy_r_r6;
 CPyL4: ;
@@ -23064,7 +23094,7 @@ CPyL10: ;
     }
     CPy_Unreachable();
 CPyL12: ;
-    cpy_r_r18 = CPyStatics[326]; /* 3 */
+    cpy_r_r18 = CPyStatics[327]; /* 3 */
     PyObject *cpy_r_r19[2] = {cpy_r_r18, cpy_r_r13};
     cpy_r_r20 = (PyObject **)&cpy_r_r19;
     cpy_r_r21 = PyObject_Vectorcall(cpy_r_r16, cpy_r_r20, 2, 0);
@@ -24028,7 +24058,7 @@ PyObject *CPyDef_humanize____consume_leading_zero_units_gen___close(PyObject *cp
     char cpy_r_r14;
     PyObject *cpy_r_r15;
     cpy_r_r0 = CPyModule_builtins;
-    cpy_r_r1 = CPyStatics[251]; /* 'GeneratorExit' */
+    cpy_r_r1 = CPyStatics[252]; /* 'GeneratorExit' */
     cpy_r_r2 = CPyObject_GetAttr(cpy_r_r0, cpy_r_r1);
     if (cpy_r_r2 == NULL) goto CPyL3;
     cpy_r_r3 = (PyObject *)&_Py_NoneStruct;
@@ -24038,7 +24068,7 @@ PyObject *CPyDef_humanize____consume_leading_zero_units_gen___close(PyObject *cp
 CPyL3: ;
     cpy_r_r6 = CPy_CatchError();
     cpy_r_r7 = CPyModule_builtins;
-    cpy_r_r8 = CPyStatics[252]; /* 'StopIteration' */
+    cpy_r_r8 = CPyStatics[253]; /* 'StopIteration' */
     cpy_r_r9 = CPyObject_GetAttr(cpy_r_r7, cpy_r_r8);
     if (cpy_r_r9 == NULL) goto CPyL12;
     cpy_r_r10.f0 = cpy_r_r2;
@@ -24904,7 +24934,7 @@ PyObject *CPyDef_humanize____humanize_seconds_gen___close(PyObject *cpy_r___mypy
     char cpy_r_r14;
     PyObject *cpy_r_r15;
     cpy_r_r0 = CPyModule_builtins;
-    cpy_r_r1 = CPyStatics[251]; /* 'GeneratorExit' */
+    cpy_r_r1 = CPyStatics[252]; /* 'GeneratorExit' */
     cpy_r_r2 = CPyObject_GetAttr(cpy_r_r0, cpy_r_r1);
     if (cpy_r_r2 == NULL) goto CPyL3;
     cpy_r_r3 = (PyObject *)&_Py_NoneStruct;
@@ -24914,7 +24944,7 @@ PyObject *CPyDef_humanize____humanize_seconds_gen___close(PyObject *cpy_r___mypy
 CPyL3: ;
     cpy_r_r6 = CPy_CatchError();
     cpy_r_r7 = CPyModule_builtins;
-    cpy_r_r8 = CPyStatics[252]; /* 'StopIteration' */
+    cpy_r_r8 = CPyStatics[253]; /* 'StopIteration' */
     cpy_r_r9 = CPyObject_GetAttr(cpy_r_r7, cpy_r_r8);
     if (cpy_r_r9 == NULL) goto CPyL12;
     cpy_r_r10.f0 = cpy_r_r2;
@@ -25094,7 +25124,7 @@ PyObject *CPyDef_humanize___humanize_bytes(PyObject *cpy_r_value) {
     cpy_r_r2 = cpy_r_r1 << 1;
     cpy_r_r3 = (Py_ssize_t)cpy_r_r2 <= (Py_ssize_t)10;
     if (!cpy_r_r3) goto CPyL4;
-    cpy_r_r4 = CPyStatics[133]; /* 'hex' */
+    cpy_r_r4 = CPyStatics[134]; /* 'hex' */
     PyObject *cpy_r_r5[1] = {cpy_r_value};
     cpy_r_r6 = (PyObject **)&cpy_r_r5;
     cpy_r_r7 = PyObject_VectorcallMethod(cpy_r_r4, cpy_r_r6, 9223372036854775809ULL, 0);
@@ -25110,7 +25140,7 @@ PyObject *CPyDef_humanize___humanize_bytes(PyObject *cpy_r_value) {
     }
     return cpy_r_r8;
 CPyL4: ;
-    cpy_r_r9 = CPyStatics[133]; /* 'hex' */
+    cpy_r_r9 = CPyStatics[134]; /* 'hex' */
     PyObject *cpy_r_r10[1] = {cpy_r_value};
     cpy_r_r11 = (PyObject **)&cpy_r_r10;
     cpy_r_r12 = PyObject_VectorcallMethod(cpy_r_r9, cpy_r_r11, 9223372036854775809ULL, 0);
@@ -25147,7 +25177,7 @@ CPyL4: ;
         CPy_TypeErrorTraceback("faster_eth_utils/humanize.py", "humanize_bytes", 93, CPyStatic_humanize___globals, "str", cpy_r_r16);
         goto CPyL14;
     }
-    cpy_r_r18 = CPyStatics[253]; /* '..' */
+    cpy_r_r18 = CPyStatics[254]; /* '..' */
     cpy_r_r19 = CPyStr_Build(3, cpy_r_r15, cpy_r_r18, cpy_r_r17);
     CPy_DECREF(cpy_r_r15);
     CPy_DECREF(cpy_r_r17);
@@ -25243,7 +25273,7 @@ PyObject *CPyDef_humanize___humanize_hexstr(PyObject *cpy_r_value) {
         CPy_TypeErrorTraceback("faster_eth_utils/humanize.py", "humanize_hexstr", 100, CPyStatic_humanize___globals, "str", cpy_r_r2);
         goto CPyL25;
     }
-    cpy_r_r4 = CPyStatics[240]; /* '0x' */
+    cpy_r_r4 = CPyStatics[241]; /* '0x' */
     cpy_r_r5 = PyUnicode_Compare(cpy_r_r3, cpy_r_r4);
     CPy_DECREF(cpy_r_r3);
     cpy_r_r6 = cpy_r_r5 == -1;
@@ -25299,8 +25329,8 @@ CPyL13: ;
         goto CPyL25;
     }
     cpy_r_head = cpy_r_r18;
-    cpy_r_r19 = CPyStatics[240]; /* '0x' */
-    cpy_r_r20 = CPyStatics[253]; /* '..' */
+    cpy_r_r19 = CPyStatics[241]; /* '0x' */
+    cpy_r_r20 = CPyStatics[254]; /* '..' */
     cpy_r_r21 = CPyStr_Build(4, cpy_r_r19, cpy_r_head, cpy_r_r20, cpy_r_r1);
     CPy_DECREF(cpy_r_head);
     CPy_DECREF(cpy_r_r1);
@@ -25338,7 +25368,7 @@ CPyL20: ;
         goto CPyL25;
     }
     cpy_r_head = cpy_r_r27;
-    cpy_r_r28 = CPyStatics[253]; /* '..' */
+    cpy_r_r28 = CPyStatics[254]; /* '..' */
     cpy_r_r29 = CPyStr_Build(3, cpy_r_head, cpy_r_r28, cpy_r_r1);
     CPy_DECREF(cpy_r_head);
     CPy_DECREF(cpy_r_r1);
@@ -25460,7 +25490,7 @@ PyObject *CPyDef_humanize___humanize_ipfs_uri(PyObject *cpy_r_uri) {
         CPy_AddTraceback("faster_eth_utils/humanize.py", "humanize_ipfs_uri", 119, CPyStatic_humanize___globals);
         goto CPyL20;
     }
-    cpy_r_r2 = CPyStatics[254]; /* (' does not look like a valid IPFS uri. Currently, only '
+    cpy_r_r2 = CPyStatics[255]; /* (' does not look like a valid IPFS uri. Currently, only '
                                    'CIDv0 hash schemes are supported.') */
     cpy_r_r3 = CPyStr_Build(2, cpy_r_r1, cpy_r_r2);
     CPy_DECREF(cpy_r_r1);
@@ -25493,13 +25523,13 @@ PyObject *CPyDef_humanize___humanize_ipfs_uri(PyObject *cpy_r_uri) {
     CPy_Unreachable();
 CPyL8: ;
     cpy_r_r10 = CPyStatic_humanize___globals;
-    cpy_r_r11 = CPyStatics[255]; /* 'parse' */
+    cpy_r_r11 = CPyStatics[256]; /* 'parse' */
     cpy_r_r12 = CPyDict_GetItem(cpy_r_r10, cpy_r_r11);
     if (unlikely(cpy_r_r12 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/humanize.py", "humanize_ipfs_uri", 123, CPyStatic_humanize___globals);
         goto CPyL20;
     }
-    cpy_r_r13 = CPyStatics[256]; /* 'urlparse' */
+    cpy_r_r13 = CPyStatics[257]; /* 'urlparse' */
     cpy_r_r14 = CPyObject_GetAttr(cpy_r_r12, cpy_r_r13);
     CPy_DECREF(cpy_r_r12);
     if (unlikely(cpy_r_r14 == NULL)) {
@@ -25520,7 +25550,7 @@ CPyL8: ;
         CPy_TypeErrorTraceback("faster_eth_utils/humanize.py", "humanize_ipfs_uri", 123, CPyStatic_humanize___globals, "tuple", cpy_r_r17);
         goto CPyL20;
     }
-    cpy_r_r19 = CPyStatics[257]; /* 'netloc' */
+    cpy_r_r19 = CPyStatics[258]; /* 'netloc' */
     cpy_r_r20 = CPyObject_GetAttr(cpy_r_r18, cpy_r_r19);
     CPy_DECREF(cpy_r_r18);
     if (unlikely(cpy_r_r20 == NULL)) {
@@ -25556,8 +25586,8 @@ CPyL8: ;
         CPy_TypeErrorTraceback("faster_eth_utils/humanize.py", "humanize_ipfs_uri", 126, CPyStatic_humanize___globals, "str", cpy_r_r24);
         goto CPyL23;
     }
-    cpy_r_r26 = CPyStatics[258]; /* 'ipfs://' */
-    cpy_r_r27 = CPyStatics[253]; /* '..' */
+    cpy_r_r26 = CPyStatics[259]; /* 'ipfs://' */
+    cpy_r_r27 = CPyStatics[254]; /* '..' */
     cpy_r_r28 = CPyStr_Build(4, cpy_r_r26, cpy_r_r23, cpy_r_r27, cpy_r_r25);
     CPy_DECREF(cpy_r_r23);
     CPy_DECREF(cpy_r_r25);
@@ -25647,13 +25677,13 @@ CPyL3: ;
         goto CPyL22;
     }
     cpy_r_r5 = CPyStatic_humanize___globals;
-    cpy_r_r6 = CPyStatics[255]; /* 'parse' */
+    cpy_r_r6 = CPyStatics[256]; /* 'parse' */
     cpy_r_r7 = CPyDict_GetItem(cpy_r_r5, cpy_r_r6);
     if (unlikely(cpy_r_r7 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/humanize.py", "is_ipfs_uri", 134, CPyStatic_humanize___globals);
         goto CPyL23;
     }
-    cpy_r_r8 = CPyStatics[256]; /* 'urlparse' */
+    cpy_r_r8 = CPyStatics[257]; /* 'urlparse' */
     cpy_r_r9 = CPyObject_GetAttr(cpy_r_r7, cpy_r_r8);
     CPy_DECREF(cpy_r_r7);
     if (unlikely(cpy_r_r9 == NULL)) {
@@ -25675,7 +25705,7 @@ CPyL3: ;
         CPy_TypeErrorTraceback("faster_eth_utils/humanize.py", "is_ipfs_uri", 134, CPyStatic_humanize___globals, "tuple", cpy_r_r12);
         goto CPyL22;
     }
-    cpy_r_r14 = CPyStatics[259]; /* 'scheme' */
+    cpy_r_r14 = CPyStatics[260]; /* 'scheme' */
     cpy_r_r15 = CPyObject_GetAttr(cpy_r_r13, cpy_r_r14);
     if (unlikely(cpy_r_r15 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/humanize.py", "is_ipfs_uri", 135, CPyStatic_humanize___globals);
@@ -25687,7 +25717,7 @@ CPyL3: ;
         CPy_TypeErrorTraceback("faster_eth_utils/humanize.py", "is_ipfs_uri", 135, CPyStatic_humanize___globals, "str", cpy_r_r15);
         goto CPyL24;
     }
-    cpy_r_r17 = CPyStatics[260]; /* 'ipfs' */
+    cpy_r_r17 = CPyStatics[261]; /* 'ipfs' */
     cpy_r_r18 = PyUnicode_Compare(cpy_r_r16, cpy_r_r17);
     CPy_DECREF(cpy_r_r16);
     cpy_r_r19 = cpy_r_r18 == -1;
@@ -25703,7 +25733,7 @@ CPyL3: ;
 CPyL13: ;
     cpy_r_r23 = cpy_r_r18 != 0;
     if (cpy_r_r23) goto CPyL25;
-    cpy_r_r24 = CPyStatics[257]; /* 'netloc' */
+    cpy_r_r24 = CPyStatics[258]; /* 'netloc' */
     cpy_r_r25 = CPyObject_GetAttr(cpy_r_r13, cpy_r_r24);
     if (unlikely(cpy_r_r25 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/humanize.py", "is_ipfs_uri", 135, CPyStatic_humanize___globals);
@@ -25724,7 +25754,7 @@ CPyL13: ;
 CPyL17: ;
     return 0;
 CPyL18: ;
-    cpy_r_r28 = CPyStatics[257]; /* 'netloc' */
+    cpy_r_r28 = CPyStatics[258]; /* 'netloc' */
     cpy_r_r29 = CPyObject_GetAttr(cpy_r_r13, cpy_r_r28);
     CPy_DECREF(cpy_r_r13);
     if (unlikely(cpy_r_r29 == NULL)) {
@@ -25787,7 +25817,7 @@ char CPyDef_humanize____is_CIDv0_ipfs_hash(PyObject *cpy_r_ipfs_hash) {
     CPyTagged cpy_r_r5;
     char cpy_r_r6;
     char cpy_r_r7;
-    cpy_r_r0 = CPyStatics[261]; /* 'Qm' */
+    cpy_r_r0 = CPyStatics[262]; /* 'Qm' */
     cpy_r_r1 = CPyStr_Startswith(cpy_r_ipfs_hash, cpy_r_r0);
     cpy_r_r2 = cpy_r_r1;
     if (!cpy_r_r2) goto CPyL4;
@@ -25932,7 +25962,7 @@ CPyL3: ;
     }
     CPy_Unreachable();
 CPyL5: ;
-    cpy_r_r4 = CPyStatics[322]; /* 0 */
+    cpy_r_r4 = CPyStatics[323]; /* 0 */
     if (((faster_eth_utils___humanize____find_breakpoints_envObject *)cpy_r_r0)->___mypyc_next_label__ != CPY_INT_TAG) {
         CPyTagged_DECREF(((faster_eth_utils___humanize____find_breakpoints_envObject *)cpy_r_r0)->___mypyc_next_label__);
     }
@@ -25980,7 +26010,7 @@ CPyL12: ;
     }
     CPy_Unreachable();
 CPyL14: ;
-    cpy_r_r11 = CPyStatics[320]; /* 2 */
+    cpy_r_r11 = CPyStatics[321]; /* 2 */
     PyObject *cpy_r_r12[2] = {cpy_r_r11, cpy_r_r8};
     cpy_r_r13 = (PyObject **)&cpy_r_r12;
     cpy_r_r14 = PyObject_Vectorcall(cpy_r_r9, cpy_r_r13, 2, 0);
@@ -25990,13 +26020,13 @@ CPyL14: ;
     }
     CPy_DECREF(cpy_r_r8);
     cpy_r_r15 = CPyModule_builtins;
-    cpy_r_r16 = CPyStatics[262]; /* 'enumerate' */
+    cpy_r_r16 = CPyStatics[263]; /* 'enumerate' */
     cpy_r_r17 = CPyObject_GetAttr(cpy_r_r15, cpy_r_r16);
     if (unlikely(cpy_r_r17 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/humanize.py", "_find_breakpoints", 149, CPyStatic_humanize___globals);
         goto CPyL70;
     }
-    cpy_r_r18 = CPyStatics[319]; /* 1 */
+    cpy_r_r18 = CPyStatics[320]; /* 1 */
     PyObject *cpy_r_r19[2] = {cpy_r_r14, cpy_r_r18};
     cpy_r_r20 = (PyObject **)&cpy_r_r19;
     cpy_r_r21 = PyObject_Vectorcall(cpy_r_r17, cpy_r_r20, 2, 0);
@@ -26166,7 +26196,7 @@ CPyL36: ;
     }
     CPy_INCREF(cpy_r_r40);
 CPyL37: ;
-    cpy_r_r41 = CPyStatics[319]; /* 1 */
+    cpy_r_r41 = CPyStatics[320]; /* 1 */
     cpy_r_r42 = PyNumber_Add(cpy_r_r40, cpy_r_r41);
     CPy_DECREF(cpy_r_r40);
     if (unlikely(cpy_r_r42 == NULL)) {
@@ -26594,7 +26624,7 @@ PyObject *CPyDef_humanize____find_breakpoints_gen___close(PyObject *cpy_r___mypy
     char cpy_r_r14;
     PyObject *cpy_r_r15;
     cpy_r_r0 = CPyModule_builtins;
-    cpy_r_r1 = CPyStatics[251]; /* 'GeneratorExit' */
+    cpy_r_r1 = CPyStatics[252]; /* 'GeneratorExit' */
     cpy_r_r2 = CPyObject_GetAttr(cpy_r_r0, cpy_r_r1);
     if (cpy_r_r2 == NULL) goto CPyL3;
     cpy_r_r3 = (PyObject *)&_Py_NoneStruct;
@@ -26604,7 +26634,7 @@ PyObject *CPyDef_humanize____find_breakpoints_gen___close(PyObject *cpy_r___mypy
 CPyL3: ;
     cpy_r_r6 = CPy_CatchError();
     cpy_r_r7 = CPyModule_builtins;
-    cpy_r_r8 = CPyStatics[252]; /* 'StopIteration' */
+    cpy_r_r8 = CPyStatics[253]; /* 'StopIteration' */
     cpy_r_r9 = CPyObject_GetAttr(cpy_r_r7, cpy_r_r8);
     if (cpy_r_r9 == NULL) goto CPyL12;
     cpy_r_r10.f0 = cpy_r_r2;
@@ -26868,7 +26898,7 @@ CPyL8: ;
     }
     CPy_Unreachable();
 CPyL10: ;
-    cpy_r_r8 = CPyStatics[320]; /* 2 */
+    cpy_r_r8 = CPyStatics[321]; /* 2 */
     PyObject *cpy_r_r9[2] = {cpy_r_r8, cpy_r_r5};
     cpy_r_r10 = (PyObject **)&cpy_r_r9;
     cpy_r_r11 = PyObject_Vectorcall(cpy_r_r6, cpy_r_r10, 2, 0);
@@ -27417,7 +27447,7 @@ PyObject *CPyDef_humanize____extract_integer_ranges_gen___close(PyObject *cpy_r_
     char cpy_r_r14;
     PyObject *cpy_r_r15;
     cpy_r_r0 = CPyModule_builtins;
-    cpy_r_r1 = CPyStatics[251]; /* 'GeneratorExit' */
+    cpy_r_r1 = CPyStatics[252]; /* 'GeneratorExit' */
     cpy_r_r2 = CPyObject_GetAttr(cpy_r_r0, cpy_r_r1);
     if (cpy_r_r2 == NULL) goto CPyL3;
     cpy_r_r3 = (PyObject *)&_Py_NoneStruct;
@@ -27427,7 +27457,7 @@ PyObject *CPyDef_humanize____extract_integer_ranges_gen___close(PyObject *cpy_r_
 CPyL3: ;
     cpy_r_r6 = CPy_CatchError();
     cpy_r_r7 = CPyModule_builtins;
-    cpy_r_r8 = CPyStatics[252]; /* 'StopIteration' */
+    cpy_r_r8 = CPyStatics[253]; /* 'StopIteration' */
     cpy_r_r9 = CPyObject_GetAttr(cpy_r_r7, cpy_r_r8);
     if (cpy_r_r9 == NULL) goto CPyL12;
     cpy_r_r10.f0 = cpy_r_r2;
@@ -27633,7 +27663,7 @@ CPyL5: ;
         CPy_AddTraceback("faster_eth_utils/humanize.py", "_humanize_range", 177, CPyStatic_humanize___globals);
         goto CPyL11;
     }
-    cpy_r_r10 = CPyStatics[263]; /* '-' */
+    cpy_r_r10 = CPyStatics[264]; /* '-' */
     cpy_r_r11 = CPyTagged_Str(cpy_r_r3);
     CPyTagged_DECREF(cpy_r_r3);
     if (unlikely(cpy_r_r11 == NULL)) {
@@ -27751,11 +27781,11 @@ PyObject *CPyDef_humanize___humanize_integer_sequence(PyObject *cpy_r_values_ite
     } else
         goto CPyL16;
 CPyL3: ;
-    cpy_r_r4 = CPyStatics[264]; /* '(empty)' */
+    cpy_r_r4 = CPyStatics[265]; /* '(empty)' */
     CPy_INCREF(cpy_r_r4);
     return cpy_r_r4;
 CPyL4: ;
-    cpy_r_r5 = CPyStatics[265]; /* '|' */
+    cpy_r_r5 = CPyStatics[266]; /* '|' */
     cpy_r_r6 = PyList_New(0);
     if (unlikely(cpy_r_r6 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/humanize.py", "humanize_integer_sequence", 193, CPyStatic_humanize___globals);
@@ -27939,7 +27969,7 @@ CPyL6: ;
     cpy_r_r8 = (Py_ssize_t)cpy_r_number >= (Py_ssize_t)cpy_r_r0;
     if (!cpy_r_r8) goto CPyL8;
 CPyL7: ;
-    cpy_r_r9 = CPyStatics[172]; /* 'ether' */
+    cpy_r_r9 = CPyStatics[173]; /* 'ether' */
     CPy_INCREF(cpy_r_r9);
     cpy_r_unit = cpy_r_r9;
     goto CPyL17;
@@ -27971,12 +28001,12 @@ CPyL14: ;
     cpy_r_r18 = (Py_ssize_t)cpy_r_number >= (Py_ssize_t)cpy_r_r10;
     if (!cpy_r_r18) goto CPyL16;
 CPyL15: ;
-    cpy_r_r19 = CPyStatics[162]; /* 'gwei' */
+    cpy_r_r19 = CPyStatics[163]; /* 'gwei' */
     CPy_INCREF(cpy_r_r19);
     cpy_r_unit = cpy_r_r19;
     goto CPyL17;
 CPyL16: ;
-    cpy_r_r20 = CPyStatics[155]; /* 'wei' */
+    cpy_r_r20 = CPyStatics[156]; /* 'wei' */
     CPy_INCREF(cpy_r_r20);
     cpy_r_unit = cpy_r_r20;
 CPyL17: ;
@@ -28147,7 +28177,7 @@ char CPyDef_humanize_____top_level__(void) {
     CPy_INCREF(CPyModule_builtins);
     CPy_DECREF(cpy_r_r4);
 CPyL3: ;
-    cpy_r_r5 = CPyStatics[381]; /* ('Any', 'Final', 'Iterable', 'Iterator', 'Tuple', 'Union') */
+    cpy_r_r5 = CPyStatics[383]; /* ('Any', 'Final', 'Iterable', 'Iterator', 'Tuple', 'Union') */
     cpy_r_r6 = CPyStatics[81]; /* 'typing' */
     cpy_r_r7 = CPyStatic_humanize___globals;
     cpy_r_r8 = CPyImport_ImportFromMany(cpy_r_r6, cpy_r_r5, cpy_r_r5, cpy_r_r7);
@@ -28158,8 +28188,8 @@ CPyL3: ;
     CPyModule_typing = cpy_r_r8;
     CPy_INCREF(CPyModule_typing);
     CPy_DECREF(cpy_r_r8);
-    cpy_r_r9 = CPyStatics[382]; /* ('parse',) */
-    cpy_r_r10 = CPyStatics[267]; /* 'urllib' */
+    cpy_r_r9 = CPyStatics[384]; /* ('parse',) */
+    cpy_r_r10 = CPyStatics[268]; /* 'urllib' */
     cpy_r_r11 = CPyStatic_humanize___globals;
     cpy_r_r12 = CPyImport_ImportFromMany(cpy_r_r10, cpy_r_r9, cpy_r_r9, cpy_r_r11);
     if (unlikely(cpy_r_r12 == NULL)) {
@@ -28169,7 +28199,7 @@ CPyL3: ;
     CPyModule_urllib = cpy_r_r12;
     CPy_INCREF(CPyModule_urllib);
     CPy_DECREF(cpy_r_r12);
-    cpy_r_r13 = CPyStatics[383]; /* ('URI', 'Hash32') */
+    cpy_r_r13 = CPyStatics[385]; /* ('URI', 'Hash32') */
     cpy_r_r14 = CPyStatics[91]; /* 'eth_typing' */
     cpy_r_r15 = CPyStatic_humanize___globals;
     cpy_r_r16 = CPyImport_ImportFromMany(cpy_r_r14, cpy_r_r13, cpy_r_r13, cpy_r_r15);
@@ -28180,8 +28210,8 @@ CPyL3: ;
     CPyModule_eth_typing = cpy_r_r16;
     CPy_INCREF(CPyModule_eth_typing);
     CPy_DECREF(cpy_r_r16);
-    cpy_r_r17 = CPyStatics[384]; /* ('denoms', 'from_wei') */
-    cpy_r_r18 = CPyStatics[196]; /* 'faster_eth_utils.currency' */
+    cpy_r_r17 = CPyStatics[386]; /* ('denoms', 'from_wei') */
+    cpy_r_r18 = CPyStatics[197]; /* 'faster_eth_utils.currency' */
     cpy_r_r19 = CPyStatic_humanize___globals;
     cpy_r_r20 = CPyImport_ImportFromMany(cpy_r_r18, cpy_r_r17, cpy_r_r17, cpy_r_r19);
     if (unlikely(cpy_r_r20 == NULL)) {
@@ -28191,8 +28221,8 @@ CPyL3: ;
     CPyModule_faster_eth_utils___currency = cpy_r_r20;
     CPy_INCREF(CPyModule_faster_eth_utils___currency);
     CPy_DECREF(cpy_r_r20);
-    cpy_r_r21 = CPyStatics[385]; /* ('toolz',) */
-    cpy_r_r22 = CPyStatics[272]; /* 'faster_eth_utils' */
+    cpy_r_r21 = CPyStatics[387]; /* ('toolz',) */
+    cpy_r_r22 = CPyStatics[273]; /* 'faster_eth_utils' */
     cpy_r_r23 = CPyStatic_humanize___globals;
     cpy_r_r24 = CPyImport_ImportFromMany(cpy_r_r22, cpy_r_r21, cpy_r_r21, cpy_r_r23);
     if (unlikely(cpy_r_r24 == NULL)) {
@@ -28203,13 +28233,13 @@ CPyL3: ;
     CPy_INCREF(CPyModule_faster_eth_utils);
     CPy_DECREF(cpy_r_r24);
     cpy_r_r25 = CPyStatic_humanize___globals;
-    cpy_r_r26 = CPyStatics[271]; /* 'toolz' */
+    cpy_r_r26 = CPyStatics[272]; /* 'toolz' */
     cpy_r_r27 = CPyDict_GetItem(cpy_r_r25, cpy_r_r26);
     if (unlikely(cpy_r_r27 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/humanize.py", "<module>", 26, CPyStatic_humanize___globals);
         goto CPyL24;
     }
-    cpy_r_r28 = CPyStatics[273]; /* 'sliding_window' */
+    cpy_r_r28 = CPyStatics[274]; /* 'sliding_window' */
     cpy_r_r29 = CPyObject_GetAttr(cpy_r_r27, cpy_r_r28);
     CPy_DECREF(cpy_r_r27);
     if (unlikely(cpy_r_r29 == NULL)) {
@@ -28219,7 +28249,7 @@ CPyL3: ;
     CPyStatic_humanize___sliding_window = cpy_r_r29;
     CPy_INCREF(CPyStatic_humanize___sliding_window);
     cpy_r_r30 = CPyStatic_humanize___globals;
-    cpy_r_r31 = CPyStatics[273]; /* 'sliding_window' */
+    cpy_r_r31 = CPyStatics[274]; /* 'sliding_window' */
     cpy_r_r32 = CPyDict_SetItem(cpy_r_r30, cpy_r_r31, cpy_r_r29);
     CPy_DECREF(cpy_r_r29);
     cpy_r_r33 = cpy_r_r32 >= 0;
@@ -28228,13 +28258,13 @@ CPyL3: ;
         goto CPyL24;
     }
     cpy_r_r34 = CPyStatic_humanize___globals;
-    cpy_r_r35 = CPyStatics[271]; /* 'toolz' */
+    cpy_r_r35 = CPyStatics[272]; /* 'toolz' */
     cpy_r_r36 = CPyDict_GetItem(cpy_r_r34, cpy_r_r35);
     if (unlikely(cpy_r_r36 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/humanize.py", "<module>", 27, CPyStatic_humanize___globals);
         goto CPyL24;
     }
-    cpy_r_r37 = CPyStatics[274]; /* 'take' */
+    cpy_r_r37 = CPyStatics[275]; /* 'take' */
     cpy_r_r38 = CPyObject_GetAttr(cpy_r_r36, cpy_r_r37);
     CPy_DECREF(cpy_r_r36);
     if (unlikely(cpy_r_r38 == NULL)) {
@@ -28244,7 +28274,7 @@ CPyL3: ;
     CPyStatic_humanize___take = cpy_r_r38;
     CPy_INCREF(CPyStatic_humanize___take);
     cpy_r_r39 = CPyStatic_humanize___globals;
-    cpy_r_r40 = CPyStatics[274]; /* 'take' */
+    cpy_r_r40 = CPyStatics[275]; /* 'take' */
     cpy_r_r41 = CPyDict_SetItem(cpy_r_r39, cpy_r_r40, cpy_r_r38);
     CPy_DECREF(cpy_r_r38);
     cpy_r_r42 = cpy_r_r41 >= 0;
@@ -28253,8 +28283,8 @@ CPyL3: ;
         goto CPyL24;
     }
     cpy_r_r43 = CPyStatic_humanize___globals;
-    cpy_r_r44 = CPyStatics[275]; /* 'SECOND' */
-    cpy_r_r45 = CPyStatics[319]; /* 1 */
+    cpy_r_r44 = CPyStatics[276]; /* 'SECOND' */
+    cpy_r_r45 = CPyStatics[320]; /* 1 */
     cpy_r_r46 = CPyDict_SetItem(cpy_r_r43, cpy_r_r44, cpy_r_r45);
     cpy_r_r47 = cpy_r_r46 >= 0;
     if (unlikely(!cpy_r_r47)) {
@@ -28262,8 +28292,8 @@ CPyL3: ;
         goto CPyL24;
     }
     cpy_r_r48 = CPyStatic_humanize___globals;
-    cpy_r_r49 = CPyStatics[276]; /* 'MINUTE' */
-    cpy_r_r50 = CPyStatics[327]; /* 60 */
+    cpy_r_r49 = CPyStatics[277]; /* 'MINUTE' */
+    cpy_r_r50 = CPyStatics[328]; /* 60 */
     cpy_r_r51 = CPyDict_SetItem(cpy_r_r48, cpy_r_r49, cpy_r_r50);
     cpy_r_r52 = cpy_r_r51 >= 0;
     if (unlikely(!cpy_r_r52)) {
@@ -28271,8 +28301,8 @@ CPyL3: ;
         goto CPyL24;
     }
     cpy_r_r53 = CPyStatic_humanize___globals;
-    cpy_r_r54 = CPyStatics[277]; /* 'HOUR' */
-    cpy_r_r55 = CPyStatics[328]; /* 3600 */
+    cpy_r_r54 = CPyStatics[278]; /* 'HOUR' */
+    cpy_r_r55 = CPyStatics[329]; /* 3600 */
     cpy_r_r56 = CPyDict_SetItem(cpy_r_r53, cpy_r_r54, cpy_r_r55);
     cpy_r_r57 = cpy_r_r56 >= 0;
     if (unlikely(!cpy_r_r57)) {
@@ -28280,8 +28310,8 @@ CPyL3: ;
         goto CPyL24;
     }
     cpy_r_r58 = CPyStatic_humanize___globals;
-    cpy_r_r59 = CPyStatics[278]; /* 'DAY' */
-    cpy_r_r60 = CPyStatics[329]; /* 86400 */
+    cpy_r_r59 = CPyStatics[279]; /* 'DAY' */
+    cpy_r_r60 = CPyStatics[330]; /* 86400 */
     cpy_r_r61 = CPyDict_SetItem(cpy_r_r58, cpy_r_r59, cpy_r_r60);
     cpy_r_r62 = cpy_r_r61 >= 0;
     if (unlikely(!cpy_r_r62)) {
@@ -28289,8 +28319,8 @@ CPyL3: ;
         goto CPyL24;
     }
     cpy_r_r63 = CPyStatic_humanize___globals;
-    cpy_r_r64 = CPyStatics[279]; /* 'YEAR' */
-    cpy_r_r65 = CPyStatics[330]; /* 31536000 */
+    cpy_r_r64 = CPyStatics[280]; /* 'YEAR' */
+    cpy_r_r65 = CPyStatics[331]; /* 31536000 */
     cpy_r_r66 = CPyDict_SetItem(cpy_r_r63, cpy_r_r64, cpy_r_r65);
     cpy_r_r67 = cpy_r_r66 >= 0;
     if (unlikely(!cpy_r_r67)) {
@@ -28298,8 +28328,8 @@ CPyL3: ;
         goto CPyL24;
     }
     cpy_r_r68 = CPyStatic_humanize___globals;
-    cpy_r_r69 = CPyStatics[280]; /* 'MONTH' */
-    cpy_r_r70 = CPyStatics[331]; /* 2628000 */
+    cpy_r_r69 = CPyStatics[281]; /* 'MONTH' */
+    cpy_r_r70 = CPyStatics[332]; /* 2628000 */
     cpy_r_r71 = CPyDict_SetItem(cpy_r_r68, cpy_r_r69, cpy_r_r70);
     cpy_r_r72 = cpy_r_r71 >= 0;
     if (unlikely(!cpy_r_r72)) {
@@ -28307,39 +28337,39 @@ CPyL3: ;
         goto CPyL24;
     }
     cpy_r_r73 = CPyStatic_humanize___globals;
-    cpy_r_r74 = CPyStatics[281]; /* 'WEEK' */
-    cpy_r_r75 = CPyStatics[332]; /* 604800 */
+    cpy_r_r74 = CPyStatics[282]; /* 'WEEK' */
+    cpy_r_r75 = CPyStatics[333]; /* 604800 */
     cpy_r_r76 = CPyDict_SetItem(cpy_r_r73, cpy_r_r74, cpy_r_r75);
     cpy_r_r77 = cpy_r_r76 >= 0;
     if (unlikely(!cpy_r_r77)) {
         CPy_AddTraceback("faster_eth_utils/humanize.py", "<module>", 45, CPyStatic_humanize___globals);
         goto CPyL24;
     }
-    cpy_r_r78 = CPyStatics[282]; /* 'y' */
+    cpy_r_r78 = CPyStatics[283]; /* 'y' */
     CPy_INCREF(cpy_r_r78);
     cpy_r_r79.f0 = 63072000;
     cpy_r_r79.f1 = cpy_r_r78;
-    cpy_r_r80 = CPyStatics[283]; /* 'm' */
+    cpy_r_r80 = CPyStatics[284]; /* 'm' */
     CPy_INCREF(cpy_r_r80);
     cpy_r_r81.f0 = 5256000;
     cpy_r_r81.f1 = cpy_r_r80;
-    cpy_r_r82 = CPyStatics[284]; /* 'w' */
+    cpy_r_r82 = CPyStatics[285]; /* 'w' */
     CPy_INCREF(cpy_r_r82);
     cpy_r_r83.f0 = 1209600;
     cpy_r_r83.f1 = cpy_r_r82;
-    cpy_r_r84 = CPyStatics[285]; /* 'd' */
+    cpy_r_r84 = CPyStatics[286]; /* 'd' */
     CPy_INCREF(cpy_r_r84);
     cpy_r_r85.f0 = 172800;
     cpy_r_r85.f1 = cpy_r_r84;
-    cpy_r_r86 = CPyStatics[286]; /* 'h' */
+    cpy_r_r86 = CPyStatics[287]; /* 'h' */
     CPy_INCREF(cpy_r_r86);
     cpy_r_r87.f0 = 7200;
     cpy_r_r87.f1 = cpy_r_r86;
-    cpy_r_r88 = CPyStatics[283]; /* 'm' */
+    cpy_r_r88 = CPyStatics[284]; /* 'm' */
     CPy_INCREF(cpy_r_r88);
     cpy_r_r89.f0 = 120;
     cpy_r_r89.f1 = cpy_r_r88;
-    cpy_r_r90 = CPyStatics[287]; /* 's' */
+    cpy_r_r90 = CPyStatics[288]; /* 's' */
     CPy_INCREF(cpy_r_r90);
     cpy_r_r91.f0 = 2;
     cpy_r_r91.f1 = cpy_r_r90;
@@ -28366,7 +28396,7 @@ CPyL3: ;
     CPyTagged_INCREF(CPyStatic_humanize___UNITS.f6.f0);
     CPy_INCREF(CPyStatic_humanize___UNITS.f6.f1);
     cpy_r_r93 = CPyStatic_humanize___globals;
-    cpy_r_r94 = CPyStatics[288]; /* 'UNITS' */
+    cpy_r_r94 = CPyStatics[289]; /* 'UNITS' */
     cpy_r_r95 = PyTuple_New(7);
     if (unlikely(cpy_r_r95 == NULL))
         CPyError_OutOfMemory();
@@ -28434,8 +28464,8 @@ CPyL3: ;
         goto CPyL24;
     }
     cpy_r_r98 = CPyStatic_humanize___globals;
-    cpy_r_r99 = CPyStatics[289]; /* 'DISPLAY_HASH_CHARS' */
-    cpy_r_r100 = CPyStatics[333]; /* 4 */
+    cpy_r_r99 = CPyStatics[290]; /* 'DISPLAY_HASH_CHARS' */
+    cpy_r_r100 = CPyStatics[334]; /* 4 */
     cpy_r_r101 = CPyDict_SetItem(cpy_r_r98, cpy_r_r99, cpy_r_r100);
     cpy_r_r102 = cpy_r_r101 >= 0;
     if (unlikely(!cpy_r_r102)) {
@@ -28541,7 +28571,7 @@ PyObject *CPyDef_module_loading___import_string(PyObject *cpy_r_dotted_path) {
     PyObject *cpy_r_r51;
     char cpy_r_r52;
     PyObject *cpy_r_r53;
-    cpy_r_r0 = CPyStatics[187]; /* '.' */
+    cpy_r_r0 = CPyStatics[188]; /* '.' */
     cpy_r_r1 = CPyStr_RSplit(cpy_r_dotted_path, cpy_r_r0, 2);
     if (unlikely(cpy_r_r1 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/module_loading.py", "import_string", 20, CPyStatic_module_loading___globals);
@@ -28591,7 +28621,7 @@ CPyL6: ;
     cpy_r_r20 = CPy_ExceptionMatches(cpy_r_r19);
     CPy_DecRef(cpy_r_r19);
     if (!cpy_r_r20) goto CPyL13;
-    cpy_r_r21 = CPyStatics[290]; /* " doesn't look like a module path" */
+    cpy_r_r21 = CPyStatics[291]; /* " doesn't look like a module path" */
     cpy_r_r22 = CPyStr_Build(2, cpy_r_dotted_path, cpy_r_r21);
     if (unlikely(cpy_r_r22 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/module_loading.py", "import_string", 22, CPyStatic_module_loading___globals);
@@ -28599,7 +28629,7 @@ CPyL6: ;
     }
     cpy_r_msg = cpy_r_r22;
     cpy_r_r23 = CPyModule_builtins;
-    cpy_r_r24 = CPyStatics[291]; /* 'ImportError' */
+    cpy_r_r24 = CPyStatics[292]; /* 'ImportError' */
     cpy_r_r25 = CPyObject_GetAttr(cpy_r_r23, cpy_r_r24);
     if (unlikely(cpy_r_r25 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/module_loading.py", "import_string", 23, CPyStatic_module_loading___globals);
@@ -28641,7 +28671,7 @@ CPyL15: ;
     CPy_Unreachable();
 CPyL17: ;
     cpy_r_r30 = CPyStatic_module_loading___globals;
-    cpy_r_r31 = CPyStatics[292]; /* 'import_module' */
+    cpy_r_r31 = CPyStatics[293]; /* 'import_module' */
     cpy_r_r32 = CPyDict_GetItem(cpy_r_r30, cpy_r_r31);
     if (unlikely(cpy_r_r32 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/module_loading.py", "import_string", 25, CPyStatic_module_loading___globals);
@@ -28676,9 +28706,9 @@ CPyL22: ;
     cpy_r_r41 = CPy_ExceptionMatches(cpy_r_r40);
     CPy_DecRef(cpy_r_r40);
     if (!cpy_r_r41) goto CPyL43;
-    cpy_r_r42 = CPyStatics[293]; /* 'Module "' */
-    cpy_r_r43 = CPyStatics[294]; /* '" does not define a "' */
-    cpy_r_r44 = CPyStatics[295]; /* '" attribute/class' */
+    cpy_r_r42 = CPyStatics[294]; /* 'Module "' */
+    cpy_r_r43 = CPyStatics[295]; /* '" does not define a "' */
+    cpy_r_r44 = CPyStatics[296]; /* '" attribute/class' */
     cpy_r_r45 = CPyStr_Build(5, cpy_r_r42, cpy_r_r14, cpy_r_r43, cpy_r_r15, cpy_r_r44);
     CPy_DecRef(cpy_r_r14);
     CPy_DecRef(cpy_r_r15);
@@ -28688,7 +28718,7 @@ CPyL22: ;
     }
     cpy_r_msg = cpy_r_r45;
     cpy_r_r46 = CPyModule_builtins;
-    cpy_r_r47 = CPyStatics[291]; /* 'ImportError' */
+    cpy_r_r47 = CPyStatics[292]; /* 'ImportError' */
     cpy_r_r48 = CPyObject_GetAttr(cpy_r_r46, cpy_r_r47);
     if (unlikely(cpy_r_r48 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/module_loading.py", "import_string", 31, CPyStatic_module_loading___globals);
@@ -28834,8 +28864,8 @@ char CPyDef_module_loading_____top_level__(void) {
     CPy_INCREF(CPyModule_builtins);
     CPy_DECREF(cpy_r_r4);
 CPyL3: ;
-    cpy_r_r5 = CPyStatics[386]; /* ('import_module',) */
-    cpy_r_r6 = CPyStatics[296]; /* 'importlib' */
+    cpy_r_r5 = CPyStatics[388]; /* ('import_module',) */
+    cpy_r_r6 = CPyStatics[297]; /* 'importlib' */
     cpy_r_r7 = CPyStatic_module_loading___globals;
     cpy_r_r8 = CPyImport_ImportFromMany(cpy_r_r6, cpy_r_r5, cpy_r_r5, cpy_r_r7);
     if (unlikely(cpy_r_r8 == NULL)) {
@@ -28845,7 +28875,7 @@ CPyL3: ;
     CPyModule_importlib = cpy_r_r8;
     CPy_INCREF(CPyModule_importlib);
     CPy_DECREF(cpy_r_r8);
-    cpy_r_r9 = CPyStatics[387]; /* ('Any',) */
+    cpy_r_r9 = CPyStatics[389]; /* ('Any',) */
     cpy_r_r10 = CPyStatics[81]; /* 'typing' */
     cpy_r_r11 = CPyStatic_module_loading___globals;
     cpy_r_r12 = CPyImport_ImportFromMany(cpy_r_r10, cpy_r_r9, cpy_r_r9, cpy_r_r11);
@@ -28929,10 +28959,10 @@ char CPyDef_types___is_integer(PyObject *cpy_r_value) {
     char cpy_r_r13;
     char cpy_r_r14;
     cpy_r_r0 = CPyStatic_types___globals;
-    cpy_r_r1 = CPyStatics[297]; /* 'integer_types' */
+    cpy_r_r1 = CPyStatics[298]; /* 'integer_types' */
     cpy_r_r2 = CPyDict_GetItem(cpy_r_r0, cpy_r_r1);
     if (unlikely(cpy_r_r2 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/types.py", "is_integer", 19, CPyStatic_types___globals);
+        CPy_AddTraceback("faster_eth_utils/types.py", "is_integer", 22, CPyStatic_types___globals);
         goto CPyL8;
     }
     PyObject *__tmp171;
@@ -28955,7 +28985,7 @@ __LL172: ;
     }
     CPy_DECREF(cpy_r_r2);
     if (unlikely(cpy_r_r3.f0 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/types.py", "is_integer", 19, CPyStatic_types___globals);
+        CPy_AddTraceback("faster_eth_utils/types.py", "is_integer", 22, CPyStatic_types___globals);
         goto CPyL8;
     }
     cpy_r_r4 = PyTuple_New(1);
@@ -28967,7 +28997,7 @@ __LL172: ;
     CPy_DECREF(cpy_r_r4);
     cpy_r_r6 = cpy_r_r5 >= 0;
     if (unlikely(!cpy_r_r6)) {
-        CPy_AddTraceback("faster_eth_utils/types.py", "is_integer", 19, CPyStatic_types___globals);
+        CPy_AddTraceback("faster_eth_utils/types.py", "is_integer", 22, CPyStatic_types___globals);
         goto CPyL8;
     }
     cpy_r_r7 = cpy_r_r5;
@@ -28979,7 +29009,7 @@ CPyL5: ;
     cpy_r_r10 = PyObject_IsInstance(cpy_r_value, cpy_r_r9);
     cpy_r_r11 = cpy_r_r10 >= 0;
     if (unlikely(!cpy_r_r11)) {
-        CPy_AddTraceback("faster_eth_utils/types.py", "is_integer", 19, CPyStatic_types___globals);
+        CPy_AddTraceback("faster_eth_utils/types.py", "is_integer", 22, CPyStatic_types___globals);
         goto CPyL8;
     }
     cpy_r_r12 = cpy_r_r10;
@@ -29008,7 +29038,7 @@ PyObject *CPyPy_types___is_integer(PyObject *self, PyObject *const *args, size_t
     CPy_INCREF(retbox);
     return retbox;
 fail: ;
-    CPy_AddTraceback("faster_eth_utils/types.py", "is_integer", 18, CPyStatic_types___globals);
+    CPy_AddTraceback("faster_eth_utils/types.py", "is_integer", 21, CPyStatic_types___globals);
     return NULL;
 }
 
@@ -29023,10 +29053,10 @@ char CPyDef_types___is_bytes(PyObject *cpy_r_value) {
     char cpy_r_r7;
     char cpy_r_r8;
     cpy_r_r0 = CPyStatic_types___globals;
-    cpy_r_r1 = CPyStatics[298]; /* 'bytes_types' */
+    cpy_r_r1 = CPyStatics[299]; /* 'bytes_types' */
     cpy_r_r2 = CPyDict_GetItem(cpy_r_r0, cpy_r_r1);
     if (unlikely(cpy_r_r2 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/types.py", "is_bytes", 23, CPyStatic_types___globals);
+        CPy_AddTraceback("faster_eth_utils/types.py", "is_bytes", 26, CPyStatic_types___globals);
         goto CPyL4;
     }
     PyObject *__tmp176;
@@ -29056,7 +29086,7 @@ __LL177: ;
     }
     CPy_DECREF(cpy_r_r2);
     if (unlikely(cpy_r_r3.f0 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/types.py", "is_bytes", 23, CPyStatic_types___globals);
+        CPy_AddTraceback("faster_eth_utils/types.py", "is_bytes", 26, CPyStatic_types___globals);
         goto CPyL4;
     }
     cpy_r_r4 = PyTuple_New(2);
@@ -29070,7 +29100,7 @@ __LL177: ;
     CPy_DECREF(cpy_r_r4);
     cpy_r_r6 = cpy_r_r5 >= 0;
     if (unlikely(!cpy_r_r6)) {
-        CPy_AddTraceback("faster_eth_utils/types.py", "is_bytes", 23, CPyStatic_types___globals);
+        CPy_AddTraceback("faster_eth_utils/types.py", "is_bytes", 26, CPyStatic_types___globals);
         goto CPyL4;
     }
     cpy_r_r7 = cpy_r_r5;
@@ -29096,7 +29126,7 @@ PyObject *CPyPy_types___is_bytes(PyObject *self, PyObject *const *args, size_t n
     CPy_INCREF(retbox);
     return retbox;
 fail: ;
-    CPy_AddTraceback("faster_eth_utils/types.py", "is_bytes", 22, CPyStatic_types___globals);
+    CPy_AddTraceback("faster_eth_utils/types.py", "is_bytes", 25, CPyStatic_types___globals);
     return NULL;
 }
 
@@ -29111,10 +29141,10 @@ char CPyDef_types___is_text(PyObject *cpy_r_value) {
     char cpy_r_r7;
     char cpy_r_r8;
     cpy_r_r0 = CPyStatic_types___globals;
-    cpy_r_r1 = CPyStatics[299]; /* 'text_types' */
+    cpy_r_r1 = CPyStatics[300]; /* 'text_types' */
     cpy_r_r2 = CPyDict_GetItem(cpy_r_r0, cpy_r_r1);
     if (unlikely(cpy_r_r2 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/types.py", "is_text", 27, CPyStatic_types___globals);
+        CPy_AddTraceback("faster_eth_utils/types.py", "is_text", 30, CPyStatic_types___globals);
         goto CPyL4;
     }
     PyObject *__tmp184;
@@ -29137,7 +29167,7 @@ __LL185: ;
     }
     CPy_DECREF(cpy_r_r2);
     if (unlikely(cpy_r_r3.f0 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/types.py", "is_text", 27, CPyStatic_types___globals);
+        CPy_AddTraceback("faster_eth_utils/types.py", "is_text", 30, CPyStatic_types___globals);
         goto CPyL4;
     }
     cpy_r_r4 = PyTuple_New(1);
@@ -29149,7 +29179,7 @@ __LL185: ;
     CPy_DECREF(cpy_r_r4);
     cpy_r_r6 = cpy_r_r5 >= 0;
     if (unlikely(!cpy_r_r6)) {
-        CPy_AddTraceback("faster_eth_utils/types.py", "is_text", 27, CPyStatic_types___globals);
+        CPy_AddTraceback("faster_eth_utils/types.py", "is_text", 30, CPyStatic_types___globals);
         goto CPyL4;
     }
     cpy_r_r7 = cpy_r_r5;
@@ -29175,7 +29205,7 @@ PyObject *CPyPy_types___is_text(PyObject *self, PyObject *const *args, size_t na
     CPy_INCREF(retbox);
     return retbox;
 fail: ;
-    CPy_AddTraceback("faster_eth_utils/types.py", "is_text", 26, CPyStatic_types___globals);
+    CPy_AddTraceback("faster_eth_utils/types.py", "is_text", 29, CPyStatic_types___globals);
     return NULL;
 }
 
@@ -29190,10 +29220,10 @@ char CPyDef_types___is_string(PyObject *cpy_r_value) {
     char cpy_r_r7;
     char cpy_r_r8;
     cpy_r_r0 = CPyStatic_types___globals;
-    cpy_r_r1 = CPyStatics[300]; /* 'string_types' */
+    cpy_r_r1 = CPyStatics[301]; /* 'string_types' */
     cpy_r_r2 = CPyDict_GetItem(cpy_r_r0, cpy_r_r1);
     if (unlikely(cpy_r_r2 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/types.py", "is_string", 31, CPyStatic_types___globals);
+        CPy_AddTraceback("faster_eth_utils/types.py", "is_string", 34, CPyStatic_types___globals);
         goto CPyL4;
     }
     PyObject *__tmp189;
@@ -29230,7 +29260,7 @@ __LL190: ;
     }
     CPy_DECREF(cpy_r_r2);
     if (unlikely(cpy_r_r3.f0 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/types.py", "is_string", 31, CPyStatic_types___globals);
+        CPy_AddTraceback("faster_eth_utils/types.py", "is_string", 34, CPyStatic_types___globals);
         goto CPyL4;
     }
     cpy_r_r4 = PyTuple_New(3);
@@ -29246,7 +29276,7 @@ __LL190: ;
     CPy_DECREF(cpy_r_r4);
     cpy_r_r6 = cpy_r_r5 >= 0;
     if (unlikely(!cpy_r_r6)) {
-        CPy_AddTraceback("faster_eth_utils/types.py", "is_string", 31, CPyStatic_types___globals);
+        CPy_AddTraceback("faster_eth_utils/types.py", "is_string", 34, CPyStatic_types___globals);
         goto CPyL4;
     }
     cpy_r_r7 = cpy_r_r5;
@@ -29272,7 +29302,7 @@ PyObject *CPyPy_types___is_string(PyObject *self, PyObject *const *args, size_t 
     CPy_INCREF(retbox);
     return retbox;
 fail: ;
-    CPy_AddTraceback("faster_eth_utils/types.py", "is_string", 30, CPyStatic_types___globals);
+    CPy_AddTraceback("faster_eth_utils/types.py", "is_string", 33, CPyStatic_types___globals);
     return NULL;
 }
 
@@ -29286,7 +29316,7 @@ char CPyDef_types___is_boolean(PyObject *cpy_r_value) {
     cpy_r_r1 = PyObject_IsInstance(cpy_r_value, cpy_r_r0);
     cpy_r_r2 = cpy_r_r1 >= 0;
     if (unlikely(!cpy_r_r2)) {
-        CPy_AddTraceback("faster_eth_utils/types.py", "is_boolean", 35, CPyStatic_types___globals);
+        CPy_AddTraceback("faster_eth_utils/types.py", "is_boolean", 38, CPyStatic_types___globals);
         goto CPyL2;
     }
     cpy_r_r3 = cpy_r_r1;
@@ -29312,7 +29342,7 @@ PyObject *CPyPy_types___is_boolean(PyObject *self, PyObject *const *args, size_t
     CPy_INCREF(retbox);
     return retbox;
 fail: ;
-    CPy_AddTraceback("faster_eth_utils/types.py", "is_boolean", 34, CPyStatic_types___globals);
+    CPy_AddTraceback("faster_eth_utils/types.py", "is_boolean", 37, CPyStatic_types___globals);
     return NULL;
 }
 
@@ -29328,14 +29358,14 @@ char CPyDef_types___is_dict(PyObject *cpy_r_obj) {
     cpy_r_r1 = CPyStatics[12]; /* 'Mapping' */
     cpy_r_r2 = CPyObject_GetAttr(cpy_r_r0, cpy_r_r1);
     if (unlikely(cpy_r_r2 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/types.py", "is_dict", 39, CPyStatic_types___globals);
+        CPy_AddTraceback("faster_eth_utils/types.py", "is_dict", 42, CPyStatic_types___globals);
         goto CPyL3;
     }
     cpy_r_r3 = PyObject_IsInstance(cpy_r_obj, cpy_r_r2);
     CPy_DECREF(cpy_r_r2);
     cpy_r_r4 = cpy_r_r3 >= 0;
     if (unlikely(!cpy_r_r4)) {
-        CPy_AddTraceback("faster_eth_utils/types.py", "is_dict", 39, CPyStatic_types___globals);
+        CPy_AddTraceback("faster_eth_utils/types.py", "is_dict", 42, CPyStatic_types___globals);
         goto CPyL3;
     }
     cpy_r_r5 = cpy_r_r3;
@@ -29361,7 +29391,7 @@ PyObject *CPyPy_types___is_dict(PyObject *self, PyObject *const *args, size_t na
     CPy_INCREF(retbox);
     return retbox;
 fail: ;
-    CPy_AddTraceback("faster_eth_utils/types.py", "is_dict", 38, CPyStatic_types___globals);
+    CPy_AddTraceback("faster_eth_utils/types.py", "is_dict", 41, CPyStatic_types___globals);
     return NULL;
 }
 
@@ -29378,7 +29408,7 @@ char CPyDef_types___is_list_like(PyObject *cpy_r_obj) {
     char cpy_r_r9;
     cpy_r_r0 = CPyDef_types___is_string(cpy_r_obj);
     if (unlikely(cpy_r_r0 == 2)) {
-        CPy_AddTraceback("faster_eth_utils/types.py", "is_list_like", 43, CPyStatic_types___globals);
+        CPy_AddTraceback("faster_eth_utils/types.py", "is_list_like", 46, CPyStatic_types___globals);
         goto CPyL7;
     }
     cpy_r_r1 = cpy_r_r0 ^ 1;
@@ -29390,14 +29420,14 @@ CPyL3: ;
     cpy_r_r4 = CPyStatics[76]; /* 'Sequence' */
     cpy_r_r5 = CPyObject_GetAttr(cpy_r_r3, cpy_r_r4);
     if (unlikely(cpy_r_r5 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/types.py", "is_list_like", 43, CPyStatic_types___globals);
+        CPy_AddTraceback("faster_eth_utils/types.py", "is_list_like", 46, CPyStatic_types___globals);
         goto CPyL7;
     }
     cpy_r_r6 = PyObject_IsInstance(cpy_r_obj, cpy_r_r5);
     CPy_DECREF(cpy_r_r5);
     cpy_r_r7 = cpy_r_r6 >= 0;
     if (unlikely(!cpy_r_r7)) {
-        CPy_AddTraceback("faster_eth_utils/types.py", "is_list_like", 43, CPyStatic_types___globals);
+        CPy_AddTraceback("faster_eth_utils/types.py", "is_list_like", 46, CPyStatic_types___globals);
         goto CPyL7;
     }
     cpy_r_r8 = cpy_r_r6;
@@ -29425,7 +29455,7 @@ PyObject *CPyPy_types___is_list_like(PyObject *self, PyObject *const *args, size
     CPy_INCREF(retbox);
     return retbox;
 fail: ;
-    CPy_AddTraceback("faster_eth_utils/types.py", "is_list_like", 42, CPyStatic_types___globals);
+    CPy_AddTraceback("faster_eth_utils/types.py", "is_list_like", 45, CPyStatic_types___globals);
     return NULL;
 }
 
@@ -29439,7 +29469,7 @@ char CPyDef_types___is_list(PyObject *cpy_r_obj) {
     cpy_r_r1 = PyObject_IsInstance(cpy_r_obj, cpy_r_r0);
     cpy_r_r2 = cpy_r_r1 >= 0;
     if (unlikely(!cpy_r_r2)) {
-        CPy_AddTraceback("faster_eth_utils/types.py", "is_list", 47, CPyStatic_types___globals);
+        CPy_AddTraceback("faster_eth_utils/types.py", "is_list", 50, CPyStatic_types___globals);
         goto CPyL2;
     }
     cpy_r_r3 = cpy_r_r1;
@@ -29465,7 +29495,7 @@ PyObject *CPyPy_types___is_list(PyObject *self, PyObject *const *args, size_t na
     CPy_INCREF(retbox);
     return retbox;
 fail: ;
-    CPy_AddTraceback("faster_eth_utils/types.py", "is_list", 46, CPyStatic_types___globals);
+    CPy_AddTraceback("faster_eth_utils/types.py", "is_list", 49, CPyStatic_types___globals);
     return NULL;
 }
 
@@ -29479,7 +29509,7 @@ char CPyDef_types___is_tuple(PyObject *cpy_r_obj) {
     cpy_r_r1 = PyObject_IsInstance(cpy_r_obj, cpy_r_r0);
     cpy_r_r2 = cpy_r_r1 >= 0;
     if (unlikely(!cpy_r_r2)) {
-        CPy_AddTraceback("faster_eth_utils/types.py", "is_tuple", 51, CPyStatic_types___globals);
+        CPy_AddTraceback("faster_eth_utils/types.py", "is_tuple", 54, CPyStatic_types___globals);
         goto CPyL2;
     }
     cpy_r_r3 = cpy_r_r1;
@@ -29505,7 +29535,7 @@ PyObject *CPyPy_types___is_tuple(PyObject *self, PyObject *const *args, size_t n
     CPy_INCREF(retbox);
     return retbox;
 fail: ;
-    CPy_AddTraceback("faster_eth_utils/types.py", "is_tuple", 50, CPyStatic_types___globals);
+    CPy_AddTraceback("faster_eth_utils/types.py", "is_tuple", 53, CPyStatic_types___globals);
     return NULL;
 }
 
@@ -29533,7 +29563,7 @@ PyObject *CPyPy_types___is_null(PyObject *self, PyObject *const *args, size_t na
     CPy_INCREF(retbox);
     return retbox;
 fail: ;
-    CPy_AddTraceback("faster_eth_utils/types.py", "is_null", 54, CPyStatic_types___globals);
+    CPy_AddTraceback("faster_eth_utils/types.py", "is_null", 57, CPyStatic_types___globals);
     return NULL;
 }
 
@@ -29546,17 +29576,17 @@ char CPyDef_types___is_number(PyObject *cpy_r_obj) {
     char cpy_r_r5;
     char cpy_r_r6;
     cpy_r_r0 = CPyModule_numbers;
-    cpy_r_r1 = CPyStatics[301]; /* 'Number' */
+    cpy_r_r1 = CPyStatics[302]; /* 'Number' */
     cpy_r_r2 = CPyObject_GetAttr(cpy_r_r0, cpy_r_r1);
     if (unlikely(cpy_r_r2 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/types.py", "is_number", 59, CPyStatic_types___globals);
+        CPy_AddTraceback("faster_eth_utils/types.py", "is_number", 62, CPyStatic_types___globals);
         goto CPyL3;
     }
     cpy_r_r3 = PyObject_IsInstance(cpy_r_obj, cpy_r_r2);
     CPy_DECREF(cpy_r_r2);
     cpy_r_r4 = cpy_r_r3 >= 0;
     if (unlikely(!cpy_r_r4)) {
-        CPy_AddTraceback("faster_eth_utils/types.py", "is_number", 59, CPyStatic_types___globals);
+        CPy_AddTraceback("faster_eth_utils/types.py", "is_number", 62, CPyStatic_types___globals);
         goto CPyL3;
     }
     cpy_r_r5 = cpy_r_r3;
@@ -29582,7 +29612,7 @@ PyObject *CPyPy_types___is_number(PyObject *self, PyObject *const *args, size_t 
     CPy_INCREF(retbox);
     return retbox;
 fail: ;
-    CPy_AddTraceback("faster_eth_utils/types.py", "is_number", 58, CPyStatic_types___globals);
+    CPy_AddTraceback("faster_eth_utils/types.py", "is_number", 61, CPyStatic_types___globals);
     return NULL;
 }
 
@@ -29609,38 +29639,42 @@ char CPyDef_types_____top_level__(void) {
     PyObject *cpy_r_r21;
     PyObject *cpy_r_r22;
     PyObject *cpy_r_r23;
-    tuple_T2OO cpy_r_r24;
+    PyObject *cpy_r_r24;
     PyObject *cpy_r_r25;
     PyObject *cpy_r_r26;
     PyObject *cpy_r_r27;
-    int32_t cpy_r_r28;
-    char cpy_r_r29;
+    tuple_T2OO cpy_r_r28;
+    PyObject *cpy_r_r29;
     PyObject *cpy_r_r30;
-    tuple_T1O cpy_r_r31;
-    PyObject *cpy_r_r32;
-    PyObject *cpy_r_r33;
+    PyObject *cpy_r_r31;
+    int32_t cpy_r_r32;
+    char cpy_r_r33;
     PyObject *cpy_r_r34;
-    int32_t cpy_r_r35;
-    char cpy_r_r36;
+    tuple_T1O cpy_r_r35;
+    PyObject *cpy_r_r36;
     PyObject *cpy_r_r37;
-    tuple_T1O cpy_r_r38;
-    PyObject *cpy_r_r39;
-    PyObject *cpy_r_r40;
+    PyObject *cpy_r_r38;
+    int32_t cpy_r_r39;
+    char cpy_r_r40;
     PyObject *cpy_r_r41;
-    int32_t cpy_r_r42;
-    char cpy_r_r43;
+    tuple_T1O cpy_r_r42;
+    PyObject *cpy_r_r43;
     PyObject *cpy_r_r44;
     PyObject *cpy_r_r45;
-    PyObject *cpy_r_r46;
-    PyObject *cpy_r_r47;
+    int32_t cpy_r_r46;
+    char cpy_r_r47;
     PyObject *cpy_r_r48;
-    tuple_T3OOO cpy_r_r49;
+    PyObject *cpy_r_r49;
     PyObject *cpy_r_r50;
     PyObject *cpy_r_r51;
     PyObject *cpy_r_r52;
-    int32_t cpy_r_r53;
-    char cpy_r_r54;
-    char cpy_r_r55;
+    tuple_T3OOO cpy_r_r53;
+    PyObject *cpy_r_r54;
+    PyObject *cpy_r_r55;
+    PyObject *cpy_r_r56;
+    int32_t cpy_r_r57;
+    char cpy_r_r58;
+    char cpy_r_r59;
     cpy_r_r0 = CPyModule_builtins;
     cpy_r_r1 = (PyObject *)&_Py_NoneStruct;
     cpy_r_r2 = cpy_r_r0 != cpy_r_r1;
@@ -29649,7 +29683,7 @@ char CPyDef_types_____top_level__(void) {
     cpy_r_r4 = PyImport_Import(cpy_r_r3);
     if (unlikely(cpy_r_r4 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/types.py", "<module>", -1, CPyStatic_types___globals);
-        goto CPyL12;
+        goto CPyL13;
     }
     CPyModule_builtins = cpy_r_r4;
     CPy_INCREF(CPyModule_builtins);
@@ -29661,121 +29695,132 @@ CPyL3: ;
     cpy_r_r8 = (void *)&cpy_r_r7;
     int64_t cpy_r_r9[2] = {1, 2};
     cpy_r_r10 = (void *)&cpy_r_r9;
-    cpy_r_r11 = CPyStatics[390]; /* (('collections.abc', 'collections', 'collections'),
+    cpy_r_r11 = CPyStatics[392]; /* (('collections.abc', 'collections', 'collections'),
                                     ('numbers', 'numbers', 'numbers')) */
     cpy_r_r12 = CPyStatic_types___globals;
-    cpy_r_r13 = CPyStatics[304]; /* 'faster_eth_utils/types.py' */
+    cpy_r_r13 = CPyStatics[305]; /* 'faster_eth_utils/types.py' */
     cpy_r_r14 = CPyStatics[70]; /* '<module>' */
     cpy_r_r15 = CPyImport_ImportMany(cpy_r_r11, cpy_r_r8, cpy_r_r12, cpy_r_r13, cpy_r_r14, cpy_r_r10);
-    if (!cpy_r_r15) goto CPyL12;
-    cpy_r_r16 = CPyStatics[391]; /* ('Any', 'List', 'Literal', 'Tuple', 'TypeGuard', 'Union') */
+    if (!cpy_r_r15) goto CPyL13;
+    cpy_r_r16 = CPyStatics[393]; /* ('Any', 'List', 'Literal', 'Tuple', 'Union') */
     cpy_r_r17 = CPyStatics[81]; /* 'typing' */
     cpy_r_r18 = CPyStatic_types___globals;
     cpy_r_r19 = CPyImport_ImportFromMany(cpy_r_r17, cpy_r_r16, cpy_r_r16, cpy_r_r18);
     if (unlikely(cpy_r_r19 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/types.py", "<module>", 3, CPyStatic_types___globals);
-        goto CPyL12;
+        goto CPyL13;
     }
     CPyModule_typing = cpy_r_r19;
     CPy_INCREF(CPyModule_typing);
     CPy_DECREF(cpy_r_r19);
-    cpy_r_r20 = (PyObject *)&PyBytes_Type;
-    cpy_r_r21 = CPyModule_builtins;
-    cpy_r_r22 = CPyStatics[130]; /* 'bytearray' */
-    cpy_r_r23 = CPyObject_GetAttr(cpy_r_r21, cpy_r_r22);
+    cpy_r_r20 = CPyStatics[350]; /* ('TypeGuard',) */
+    cpy_r_r21 = CPyStatics[115]; /* 'typing_extensions' */
+    cpy_r_r22 = CPyStatic_types___globals;
+    cpy_r_r23 = CPyImport_ImportFromMany(cpy_r_r21, cpy_r_r20, cpy_r_r20, cpy_r_r22);
     if (unlikely(cpy_r_r23 == NULL)) {
-        CPy_AddTraceback("faster_eth_utils/types.py", "<module>", 12, CPyStatic_types___globals);
-        goto CPyL12;
+        CPy_AddTraceback("faster_eth_utils/types.py", "<module>", 11, CPyStatic_types___globals);
+        goto CPyL13;
     }
-    CPy_INCREF(cpy_r_r20);
-    cpy_r_r24.f0 = cpy_r_r20;
-    cpy_r_r24.f1 = cpy_r_r23;
-    cpy_r_r25 = CPyStatic_types___globals;
-    cpy_r_r26 = CPyStatics[298]; /* 'bytes_types' */
-    cpy_r_r27 = PyTuple_New(2);
-    if (unlikely(cpy_r_r27 == NULL))
-        CPyError_OutOfMemory();
-    PyObject *__tmp200 = cpy_r_r24.f0;
-    PyTuple_SET_ITEM(cpy_r_r27, 0, __tmp200);
-    PyObject *__tmp201 = cpy_r_r24.f1;
-    PyTuple_SET_ITEM(cpy_r_r27, 1, __tmp201);
-    cpy_r_r28 = CPyDict_SetItem(cpy_r_r25, cpy_r_r26, cpy_r_r27);
-    CPy_DECREF(cpy_r_r27);
-    cpy_r_r29 = cpy_r_r28 >= 0;
-    if (unlikely(!cpy_r_r29)) {
-        CPy_AddTraceback("faster_eth_utils/types.py", "<module>", 12, CPyStatic_types___globals);
-        goto CPyL12;
-    }
-    cpy_r_r30 = (PyObject *)&PyLong_Type;
-    CPy_INCREF(cpy_r_r30);
-    cpy_r_r31.f0 = cpy_r_r30;
-    cpy_r_r32 = CPyStatic_types___globals;
-    cpy_r_r33 = CPyStatics[297]; /* 'integer_types' */
-    cpy_r_r34 = PyTuple_New(1);
-    if (unlikely(cpy_r_r34 == NULL))
-        CPyError_OutOfMemory();
-    PyObject *__tmp202 = cpy_r_r31.f0;
-    PyTuple_SET_ITEM(cpy_r_r34, 0, __tmp202);
-    cpy_r_r35 = CPyDict_SetItem(cpy_r_r32, cpy_r_r33, cpy_r_r34);
-    CPy_DECREF(cpy_r_r34);
-    cpy_r_r36 = cpy_r_r35 >= 0;
-    if (unlikely(!cpy_r_r36)) {
-        CPy_AddTraceback("faster_eth_utils/types.py", "<module>", 13, CPyStatic_types___globals);
-        goto CPyL12;
-    }
-    cpy_r_r37 = (PyObject *)&PyUnicode_Type;
-    CPy_INCREF(cpy_r_r37);
-    cpy_r_r38.f0 = cpy_r_r37;
-    cpy_r_r39 = CPyStatic_types___globals;
-    cpy_r_r40 = CPyStatics[299]; /* 'text_types' */
-    cpy_r_r41 = PyTuple_New(1);
-    if (unlikely(cpy_r_r41 == NULL))
-        CPyError_OutOfMemory();
-    PyObject *__tmp203 = cpy_r_r38.f0;
-    PyTuple_SET_ITEM(cpy_r_r41, 0, __tmp203);
-    cpy_r_r42 = CPyDict_SetItem(cpy_r_r39, cpy_r_r40, cpy_r_r41);
-    CPy_DECREF(cpy_r_r41);
-    cpy_r_r43 = cpy_r_r42 >= 0;
-    if (unlikely(!cpy_r_r43)) {
-        CPy_AddTraceback("faster_eth_utils/types.py", "<module>", 14, CPyStatic_types___globals);
-        goto CPyL12;
-    }
-    cpy_r_r44 = (PyObject *)&PyBytes_Type;
-    cpy_r_r45 = (PyObject *)&PyUnicode_Type;
-    cpy_r_r46 = CPyModule_builtins;
-    cpy_r_r47 = CPyStatics[130]; /* 'bytearray' */
-    cpy_r_r48 = CPyObject_GetAttr(cpy_r_r46, cpy_r_r47);
-    if (unlikely(cpy_r_r48 == NULL)) {
+    CPyModule_typing_extensions = cpy_r_r23;
+    CPy_INCREF(CPyModule_typing_extensions);
+    CPy_DECREF(cpy_r_r23);
+    cpy_r_r24 = (PyObject *)&PyBytes_Type;
+    cpy_r_r25 = CPyModule_builtins;
+    cpy_r_r26 = CPyStatics[131]; /* 'bytearray' */
+    cpy_r_r27 = CPyObject_GetAttr(cpy_r_r25, cpy_r_r26);
+    if (unlikely(cpy_r_r27 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/types.py", "<module>", 15, CPyStatic_types___globals);
-        goto CPyL12;
+        goto CPyL13;
     }
-    CPy_INCREF(cpy_r_r44);
-    CPy_INCREF(cpy_r_r45);
-    cpy_r_r49.f0 = cpy_r_r44;
-    cpy_r_r49.f1 = cpy_r_r45;
-    cpy_r_r49.f2 = cpy_r_r48;
-    cpy_r_r50 = CPyStatic_types___globals;
-    cpy_r_r51 = CPyStatics[300]; /* 'string_types' */
-    cpy_r_r52 = PyTuple_New(3);
-    if (unlikely(cpy_r_r52 == NULL))
+    CPy_INCREF(cpy_r_r24);
+    cpy_r_r28.f0 = cpy_r_r24;
+    cpy_r_r28.f1 = cpy_r_r27;
+    cpy_r_r29 = CPyStatic_types___globals;
+    cpy_r_r30 = CPyStatics[299]; /* 'bytes_types' */
+    cpy_r_r31 = PyTuple_New(2);
+    if (unlikely(cpy_r_r31 == NULL))
         CPyError_OutOfMemory();
-    PyObject *__tmp204 = cpy_r_r49.f0;
-    PyTuple_SET_ITEM(cpy_r_r52, 0, __tmp204);
-    PyObject *__tmp205 = cpy_r_r49.f1;
-    PyTuple_SET_ITEM(cpy_r_r52, 1, __tmp205);
-    PyObject *__tmp206 = cpy_r_r49.f2;
-    PyTuple_SET_ITEM(cpy_r_r52, 2, __tmp206);
-    cpy_r_r53 = CPyDict_SetItem(cpy_r_r50, cpy_r_r51, cpy_r_r52);
-    CPy_DECREF(cpy_r_r52);
-    cpy_r_r54 = cpy_r_r53 >= 0;
-    if (unlikely(!cpy_r_r54)) {
+    PyObject *__tmp200 = cpy_r_r28.f0;
+    PyTuple_SET_ITEM(cpy_r_r31, 0, __tmp200);
+    PyObject *__tmp201 = cpy_r_r28.f1;
+    PyTuple_SET_ITEM(cpy_r_r31, 1, __tmp201);
+    cpy_r_r32 = CPyDict_SetItem(cpy_r_r29, cpy_r_r30, cpy_r_r31);
+    CPy_DECREF(cpy_r_r31);
+    cpy_r_r33 = cpy_r_r32 >= 0;
+    if (unlikely(!cpy_r_r33)) {
         CPy_AddTraceback("faster_eth_utils/types.py", "<module>", 15, CPyStatic_types___globals);
-        goto CPyL12;
+        goto CPyL13;
+    }
+    cpy_r_r34 = (PyObject *)&PyLong_Type;
+    CPy_INCREF(cpy_r_r34);
+    cpy_r_r35.f0 = cpy_r_r34;
+    cpy_r_r36 = CPyStatic_types___globals;
+    cpy_r_r37 = CPyStatics[298]; /* 'integer_types' */
+    cpy_r_r38 = PyTuple_New(1);
+    if (unlikely(cpy_r_r38 == NULL))
+        CPyError_OutOfMemory();
+    PyObject *__tmp202 = cpy_r_r35.f0;
+    PyTuple_SET_ITEM(cpy_r_r38, 0, __tmp202);
+    cpy_r_r39 = CPyDict_SetItem(cpy_r_r36, cpy_r_r37, cpy_r_r38);
+    CPy_DECREF(cpy_r_r38);
+    cpy_r_r40 = cpy_r_r39 >= 0;
+    if (unlikely(!cpy_r_r40)) {
+        CPy_AddTraceback("faster_eth_utils/types.py", "<module>", 16, CPyStatic_types___globals);
+        goto CPyL13;
+    }
+    cpy_r_r41 = (PyObject *)&PyUnicode_Type;
+    CPy_INCREF(cpy_r_r41);
+    cpy_r_r42.f0 = cpy_r_r41;
+    cpy_r_r43 = CPyStatic_types___globals;
+    cpy_r_r44 = CPyStatics[300]; /* 'text_types' */
+    cpy_r_r45 = PyTuple_New(1);
+    if (unlikely(cpy_r_r45 == NULL))
+        CPyError_OutOfMemory();
+    PyObject *__tmp203 = cpy_r_r42.f0;
+    PyTuple_SET_ITEM(cpy_r_r45, 0, __tmp203);
+    cpy_r_r46 = CPyDict_SetItem(cpy_r_r43, cpy_r_r44, cpy_r_r45);
+    CPy_DECREF(cpy_r_r45);
+    cpy_r_r47 = cpy_r_r46 >= 0;
+    if (unlikely(!cpy_r_r47)) {
+        CPy_AddTraceback("faster_eth_utils/types.py", "<module>", 17, CPyStatic_types___globals);
+        goto CPyL13;
+    }
+    cpy_r_r48 = (PyObject *)&PyBytes_Type;
+    cpy_r_r49 = (PyObject *)&PyUnicode_Type;
+    cpy_r_r50 = CPyModule_builtins;
+    cpy_r_r51 = CPyStatics[131]; /* 'bytearray' */
+    cpy_r_r52 = CPyObject_GetAttr(cpy_r_r50, cpy_r_r51);
+    if (unlikely(cpy_r_r52 == NULL)) {
+        CPy_AddTraceback("faster_eth_utils/types.py", "<module>", 18, CPyStatic_types___globals);
+        goto CPyL13;
+    }
+    CPy_INCREF(cpy_r_r48);
+    CPy_INCREF(cpy_r_r49);
+    cpy_r_r53.f0 = cpy_r_r48;
+    cpy_r_r53.f1 = cpy_r_r49;
+    cpy_r_r53.f2 = cpy_r_r52;
+    cpy_r_r54 = CPyStatic_types___globals;
+    cpy_r_r55 = CPyStatics[301]; /* 'string_types' */
+    cpy_r_r56 = PyTuple_New(3);
+    if (unlikely(cpy_r_r56 == NULL))
+        CPyError_OutOfMemory();
+    PyObject *__tmp204 = cpy_r_r53.f0;
+    PyTuple_SET_ITEM(cpy_r_r56, 0, __tmp204);
+    PyObject *__tmp205 = cpy_r_r53.f1;
+    PyTuple_SET_ITEM(cpy_r_r56, 1, __tmp205);
+    PyObject *__tmp206 = cpy_r_r53.f2;
+    PyTuple_SET_ITEM(cpy_r_r56, 2, __tmp206);
+    cpy_r_r57 = CPyDict_SetItem(cpy_r_r54, cpy_r_r55, cpy_r_r56);
+    CPy_DECREF(cpy_r_r56);
+    cpy_r_r58 = cpy_r_r57 >= 0;
+    if (unlikely(!cpy_r_r58)) {
+        CPy_AddTraceback("faster_eth_utils/types.py", "<module>", 18, CPyStatic_types___globals);
+        goto CPyL13;
     }
     return 1;
-CPyL12: ;
-    cpy_r_r55 = 2;
-    return cpy_r_r55;
+CPyL13: ;
+    cpy_r_r59 = 2;
+    return cpy_r_r59;
 }
 static PyMethodDef unitsmodule_methods[] = {
     {NULL, NULL, 0, NULL}
@@ -30017,16 +30062,16 @@ CPyL3: ;
     cpy_r_r7 = (void *)&cpy_r_r6;
     int64_t cpy_r_r8[1] = {1};
     cpy_r_r9 = (void *)&cpy_r_r8;
-    cpy_r_r10 = CPyStatics[361]; /* (('decimal', 'decimal', 'decimal'),) */
+    cpy_r_r10 = CPyStatics[363]; /* (('decimal', 'decimal', 'decimal'),) */
     cpy_r_r11 = CPyStatic_units___globals;
-    cpy_r_r12 = CPyStatics[305]; /* 'faster_eth_utils/units.py' */
+    cpy_r_r12 = CPyStatics[306]; /* 'faster_eth_utils/units.py' */
     cpy_r_r13 = CPyStatics[70]; /* '<module>' */
     cpy_r_r14 = CPyImport_ImportMany(cpy_r_r10, cpy_r_r7, cpy_r_r11, cpy_r_r12, cpy_r_r13, cpy_r_r9);
     if (!cpy_r_r14) goto CPyL53;
-    cpy_r_r15 = CPyStatics[155]; /* 'wei' */
-    cpy_r_r16 = CPyStatics[306]; /* '1' */
+    cpy_r_r15 = CPyStatics[156]; /* 'wei' */
+    cpy_r_r16 = CPyStatics[307]; /* '1' */
     cpy_r_r17 = CPyModule_decimal;
-    cpy_r_r18 = CPyStatics[183]; /* 'Decimal' */
+    cpy_r_r18 = CPyStatics[184]; /* 'Decimal' */
     cpy_r_r19 = CPyObject_GetAttr(cpy_r_r17, cpy_r_r18);
     if (unlikely(cpy_r_r19 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/units.py", "<module>", 7, CPyStatic_units___globals);
@@ -30040,10 +30085,10 @@ CPyL3: ;
         CPy_AddTraceback("faster_eth_utils/units.py", "<module>", 7, CPyStatic_units___globals);
         goto CPyL53;
     }
-    cpy_r_r23 = CPyStatics[156]; /* 'kwei' */
-    cpy_r_r24 = CPyStatics[307]; /* '1000' */
+    cpy_r_r23 = CPyStatics[157]; /* 'kwei' */
+    cpy_r_r24 = CPyStatics[308]; /* '1000' */
     cpy_r_r25 = CPyModule_decimal;
-    cpy_r_r26 = CPyStatics[183]; /* 'Decimal' */
+    cpy_r_r26 = CPyStatics[184]; /* 'Decimal' */
     cpy_r_r27 = CPyObject_GetAttr(cpy_r_r25, cpy_r_r26);
     if (unlikely(cpy_r_r27 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/units.py", "<module>", 8, CPyStatic_units___globals);
@@ -30057,10 +30102,10 @@ CPyL3: ;
         CPy_AddTraceback("faster_eth_utils/units.py", "<module>", 8, CPyStatic_units___globals);
         goto CPyL54;
     }
-    cpy_r_r31 = CPyStatics[157]; /* 'babbage' */
-    cpy_r_r32 = CPyStatics[307]; /* '1000' */
+    cpy_r_r31 = CPyStatics[158]; /* 'babbage' */
+    cpy_r_r32 = CPyStatics[308]; /* '1000' */
     cpy_r_r33 = CPyModule_decimal;
-    cpy_r_r34 = CPyStatics[183]; /* 'Decimal' */
+    cpy_r_r34 = CPyStatics[184]; /* 'Decimal' */
     cpy_r_r35 = CPyObject_GetAttr(cpy_r_r33, cpy_r_r34);
     if (unlikely(cpy_r_r35 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/units.py", "<module>", 9, CPyStatic_units___globals);
@@ -30074,10 +30119,10 @@ CPyL3: ;
         CPy_AddTraceback("faster_eth_utils/units.py", "<module>", 9, CPyStatic_units___globals);
         goto CPyL55;
     }
-    cpy_r_r39 = CPyStatics[158]; /* 'femtoether' */
-    cpy_r_r40 = CPyStatics[307]; /* '1000' */
+    cpy_r_r39 = CPyStatics[159]; /* 'femtoether' */
+    cpy_r_r40 = CPyStatics[308]; /* '1000' */
     cpy_r_r41 = CPyModule_decimal;
-    cpy_r_r42 = CPyStatics[183]; /* 'Decimal' */
+    cpy_r_r42 = CPyStatics[184]; /* 'Decimal' */
     cpy_r_r43 = CPyObject_GetAttr(cpy_r_r41, cpy_r_r42);
     if (unlikely(cpy_r_r43 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/units.py", "<module>", 10, CPyStatic_units___globals);
@@ -30091,10 +30136,10 @@ CPyL3: ;
         CPy_AddTraceback("faster_eth_utils/units.py", "<module>", 10, CPyStatic_units___globals);
         goto CPyL56;
     }
-    cpy_r_r47 = CPyStatics[159]; /* 'mwei' */
-    cpy_r_r48 = CPyStatics[308]; /* '1000000' */
+    cpy_r_r47 = CPyStatics[160]; /* 'mwei' */
+    cpy_r_r48 = CPyStatics[309]; /* '1000000' */
     cpy_r_r49 = CPyModule_decimal;
-    cpy_r_r50 = CPyStatics[183]; /* 'Decimal' */
+    cpy_r_r50 = CPyStatics[184]; /* 'Decimal' */
     cpy_r_r51 = CPyObject_GetAttr(cpy_r_r49, cpy_r_r50);
     if (unlikely(cpy_r_r51 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/units.py", "<module>", 11, CPyStatic_units___globals);
@@ -30108,10 +30153,10 @@ CPyL3: ;
         CPy_AddTraceback("faster_eth_utils/units.py", "<module>", 11, CPyStatic_units___globals);
         goto CPyL57;
     }
-    cpy_r_r55 = CPyStatics[160]; /* 'lovelace' */
-    cpy_r_r56 = CPyStatics[308]; /* '1000000' */
+    cpy_r_r55 = CPyStatics[161]; /* 'lovelace' */
+    cpy_r_r56 = CPyStatics[309]; /* '1000000' */
     cpy_r_r57 = CPyModule_decimal;
-    cpy_r_r58 = CPyStatics[183]; /* 'Decimal' */
+    cpy_r_r58 = CPyStatics[184]; /* 'Decimal' */
     cpy_r_r59 = CPyObject_GetAttr(cpy_r_r57, cpy_r_r58);
     if (unlikely(cpy_r_r59 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/units.py", "<module>", 12, CPyStatic_units___globals);
@@ -30125,10 +30170,10 @@ CPyL3: ;
         CPy_AddTraceback("faster_eth_utils/units.py", "<module>", 12, CPyStatic_units___globals);
         goto CPyL58;
     }
-    cpy_r_r63 = CPyStatics[161]; /* 'picoether' */
-    cpy_r_r64 = CPyStatics[308]; /* '1000000' */
+    cpy_r_r63 = CPyStatics[162]; /* 'picoether' */
+    cpy_r_r64 = CPyStatics[309]; /* '1000000' */
     cpy_r_r65 = CPyModule_decimal;
-    cpy_r_r66 = CPyStatics[183]; /* 'Decimal' */
+    cpy_r_r66 = CPyStatics[184]; /* 'Decimal' */
     cpy_r_r67 = CPyObject_GetAttr(cpy_r_r65, cpy_r_r66);
     if (unlikely(cpy_r_r67 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/units.py", "<module>", 13, CPyStatic_units___globals);
@@ -30142,10 +30187,10 @@ CPyL3: ;
         CPy_AddTraceback("faster_eth_utils/units.py", "<module>", 13, CPyStatic_units___globals);
         goto CPyL59;
     }
-    cpy_r_r71 = CPyStatics[162]; /* 'gwei' */
-    cpy_r_r72 = CPyStatics[309]; /* '1000000000' */
+    cpy_r_r71 = CPyStatics[163]; /* 'gwei' */
+    cpy_r_r72 = CPyStatics[310]; /* '1000000000' */
     cpy_r_r73 = CPyModule_decimal;
-    cpy_r_r74 = CPyStatics[183]; /* 'Decimal' */
+    cpy_r_r74 = CPyStatics[184]; /* 'Decimal' */
     cpy_r_r75 = CPyObject_GetAttr(cpy_r_r73, cpy_r_r74);
     if (unlikely(cpy_r_r75 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/units.py", "<module>", 14, CPyStatic_units___globals);
@@ -30159,10 +30204,10 @@ CPyL3: ;
         CPy_AddTraceback("faster_eth_utils/units.py", "<module>", 14, CPyStatic_units___globals);
         goto CPyL60;
     }
-    cpy_r_r79 = CPyStatics[163]; /* 'shannon' */
-    cpy_r_r80 = CPyStatics[309]; /* '1000000000' */
+    cpy_r_r79 = CPyStatics[164]; /* 'shannon' */
+    cpy_r_r80 = CPyStatics[310]; /* '1000000000' */
     cpy_r_r81 = CPyModule_decimal;
-    cpy_r_r82 = CPyStatics[183]; /* 'Decimal' */
+    cpy_r_r82 = CPyStatics[184]; /* 'Decimal' */
     cpy_r_r83 = CPyObject_GetAttr(cpy_r_r81, cpy_r_r82);
     if (unlikely(cpy_r_r83 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/units.py", "<module>", 15, CPyStatic_units___globals);
@@ -30176,10 +30221,10 @@ CPyL3: ;
         CPy_AddTraceback("faster_eth_utils/units.py", "<module>", 15, CPyStatic_units___globals);
         goto CPyL61;
     }
-    cpy_r_r87 = CPyStatics[164]; /* 'nanoether' */
-    cpy_r_r88 = CPyStatics[309]; /* '1000000000' */
+    cpy_r_r87 = CPyStatics[165]; /* 'nanoether' */
+    cpy_r_r88 = CPyStatics[310]; /* '1000000000' */
     cpy_r_r89 = CPyModule_decimal;
-    cpy_r_r90 = CPyStatics[183]; /* 'Decimal' */
+    cpy_r_r90 = CPyStatics[184]; /* 'Decimal' */
     cpy_r_r91 = CPyObject_GetAttr(cpy_r_r89, cpy_r_r90);
     if (unlikely(cpy_r_r91 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/units.py", "<module>", 16, CPyStatic_units___globals);
@@ -30193,10 +30238,10 @@ CPyL3: ;
         CPy_AddTraceback("faster_eth_utils/units.py", "<module>", 16, CPyStatic_units___globals);
         goto CPyL62;
     }
-    cpy_r_r95 = CPyStatics[165]; /* 'nano' */
-    cpy_r_r96 = CPyStatics[309]; /* '1000000000' */
+    cpy_r_r95 = CPyStatics[166]; /* 'nano' */
+    cpy_r_r96 = CPyStatics[310]; /* '1000000000' */
     cpy_r_r97 = CPyModule_decimal;
-    cpy_r_r98 = CPyStatics[183]; /* 'Decimal' */
+    cpy_r_r98 = CPyStatics[184]; /* 'Decimal' */
     cpy_r_r99 = CPyObject_GetAttr(cpy_r_r97, cpy_r_r98);
     if (unlikely(cpy_r_r99 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/units.py", "<module>", 17, CPyStatic_units___globals);
@@ -30210,10 +30255,10 @@ CPyL3: ;
         CPy_AddTraceback("faster_eth_utils/units.py", "<module>", 17, CPyStatic_units___globals);
         goto CPyL63;
     }
-    cpy_r_r103 = CPyStatics[166]; /* 'szabo' */
-    cpy_r_r104 = CPyStatics[310]; /* '1000000000000' */
+    cpy_r_r103 = CPyStatics[167]; /* 'szabo' */
+    cpy_r_r104 = CPyStatics[311]; /* '1000000000000' */
     cpy_r_r105 = CPyModule_decimal;
-    cpy_r_r106 = CPyStatics[183]; /* 'Decimal' */
+    cpy_r_r106 = CPyStatics[184]; /* 'Decimal' */
     cpy_r_r107 = CPyObject_GetAttr(cpy_r_r105, cpy_r_r106);
     if (unlikely(cpy_r_r107 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/units.py", "<module>", 18, CPyStatic_units___globals);
@@ -30227,10 +30272,10 @@ CPyL3: ;
         CPy_AddTraceback("faster_eth_utils/units.py", "<module>", 18, CPyStatic_units___globals);
         goto CPyL64;
     }
-    cpy_r_r111 = CPyStatics[167]; /* 'microether' */
-    cpy_r_r112 = CPyStatics[310]; /* '1000000000000' */
+    cpy_r_r111 = CPyStatics[168]; /* 'microether' */
+    cpy_r_r112 = CPyStatics[311]; /* '1000000000000' */
     cpy_r_r113 = CPyModule_decimal;
-    cpy_r_r114 = CPyStatics[183]; /* 'Decimal' */
+    cpy_r_r114 = CPyStatics[184]; /* 'Decimal' */
     cpy_r_r115 = CPyObject_GetAttr(cpy_r_r113, cpy_r_r114);
     if (unlikely(cpy_r_r115 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/units.py", "<module>", 19, CPyStatic_units___globals);
@@ -30244,10 +30289,10 @@ CPyL3: ;
         CPy_AddTraceback("faster_eth_utils/units.py", "<module>", 19, CPyStatic_units___globals);
         goto CPyL65;
     }
-    cpy_r_r119 = CPyStatics[168]; /* 'micro' */
-    cpy_r_r120 = CPyStatics[310]; /* '1000000000000' */
+    cpy_r_r119 = CPyStatics[169]; /* 'micro' */
+    cpy_r_r120 = CPyStatics[311]; /* '1000000000000' */
     cpy_r_r121 = CPyModule_decimal;
-    cpy_r_r122 = CPyStatics[183]; /* 'Decimal' */
+    cpy_r_r122 = CPyStatics[184]; /* 'Decimal' */
     cpy_r_r123 = CPyObject_GetAttr(cpy_r_r121, cpy_r_r122);
     if (unlikely(cpy_r_r123 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/units.py", "<module>", 20, CPyStatic_units___globals);
@@ -30261,10 +30306,10 @@ CPyL3: ;
         CPy_AddTraceback("faster_eth_utils/units.py", "<module>", 20, CPyStatic_units___globals);
         goto CPyL66;
     }
-    cpy_r_r127 = CPyStatics[169]; /* 'finney' */
-    cpy_r_r128 = CPyStatics[311]; /* '1000000000000000' */
+    cpy_r_r127 = CPyStatics[170]; /* 'finney' */
+    cpy_r_r128 = CPyStatics[312]; /* '1000000000000000' */
     cpy_r_r129 = CPyModule_decimal;
-    cpy_r_r130 = CPyStatics[183]; /* 'Decimal' */
+    cpy_r_r130 = CPyStatics[184]; /* 'Decimal' */
     cpy_r_r131 = CPyObject_GetAttr(cpy_r_r129, cpy_r_r130);
     if (unlikely(cpy_r_r131 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/units.py", "<module>", 21, CPyStatic_units___globals);
@@ -30278,10 +30323,10 @@ CPyL3: ;
         CPy_AddTraceback("faster_eth_utils/units.py", "<module>", 21, CPyStatic_units___globals);
         goto CPyL67;
     }
-    cpy_r_r135 = CPyStatics[170]; /* 'milliether' */
-    cpy_r_r136 = CPyStatics[311]; /* '1000000000000000' */
+    cpy_r_r135 = CPyStatics[171]; /* 'milliether' */
+    cpy_r_r136 = CPyStatics[312]; /* '1000000000000000' */
     cpy_r_r137 = CPyModule_decimal;
-    cpy_r_r138 = CPyStatics[183]; /* 'Decimal' */
+    cpy_r_r138 = CPyStatics[184]; /* 'Decimal' */
     cpy_r_r139 = CPyObject_GetAttr(cpy_r_r137, cpy_r_r138);
     if (unlikely(cpy_r_r139 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/units.py", "<module>", 22, CPyStatic_units___globals);
@@ -30295,10 +30340,10 @@ CPyL3: ;
         CPy_AddTraceback("faster_eth_utils/units.py", "<module>", 22, CPyStatic_units___globals);
         goto CPyL68;
     }
-    cpy_r_r143 = CPyStatics[171]; /* 'milli' */
-    cpy_r_r144 = CPyStatics[311]; /* '1000000000000000' */
+    cpy_r_r143 = CPyStatics[172]; /* 'milli' */
+    cpy_r_r144 = CPyStatics[312]; /* '1000000000000000' */
     cpy_r_r145 = CPyModule_decimal;
-    cpy_r_r146 = CPyStatics[183]; /* 'Decimal' */
+    cpy_r_r146 = CPyStatics[184]; /* 'Decimal' */
     cpy_r_r147 = CPyObject_GetAttr(cpy_r_r145, cpy_r_r146);
     if (unlikely(cpy_r_r147 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/units.py", "<module>", 23, CPyStatic_units___globals);
@@ -30312,10 +30357,10 @@ CPyL3: ;
         CPy_AddTraceback("faster_eth_utils/units.py", "<module>", 23, CPyStatic_units___globals);
         goto CPyL69;
     }
-    cpy_r_r151 = CPyStatics[172]; /* 'ether' */
-    cpy_r_r152 = CPyStatics[312]; /* '1000000000000000000' */
+    cpy_r_r151 = CPyStatics[173]; /* 'ether' */
+    cpy_r_r152 = CPyStatics[313]; /* '1000000000000000000' */
     cpy_r_r153 = CPyModule_decimal;
-    cpy_r_r154 = CPyStatics[183]; /* 'Decimal' */
+    cpy_r_r154 = CPyStatics[184]; /* 'Decimal' */
     cpy_r_r155 = CPyObject_GetAttr(cpy_r_r153, cpy_r_r154);
     if (unlikely(cpy_r_r155 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/units.py", "<module>", 24, CPyStatic_units___globals);
@@ -30329,10 +30374,10 @@ CPyL3: ;
         CPy_AddTraceback("faster_eth_utils/units.py", "<module>", 24, CPyStatic_units___globals);
         goto CPyL70;
     }
-    cpy_r_r159 = CPyStatics[173]; /* 'kether' */
-    cpy_r_r160 = CPyStatics[313]; /* '1000000000000000000000' */
+    cpy_r_r159 = CPyStatics[174]; /* 'kether' */
+    cpy_r_r160 = CPyStatics[314]; /* '1000000000000000000000' */
     cpy_r_r161 = CPyModule_decimal;
-    cpy_r_r162 = CPyStatics[183]; /* 'Decimal' */
+    cpy_r_r162 = CPyStatics[184]; /* 'Decimal' */
     cpy_r_r163 = CPyObject_GetAttr(cpy_r_r161, cpy_r_r162);
     if (unlikely(cpy_r_r163 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/units.py", "<module>", 25, CPyStatic_units___globals);
@@ -30346,10 +30391,10 @@ CPyL3: ;
         CPy_AddTraceback("faster_eth_utils/units.py", "<module>", 25, CPyStatic_units___globals);
         goto CPyL71;
     }
-    cpy_r_r167 = CPyStatics[174]; /* 'grand' */
-    cpy_r_r168 = CPyStatics[313]; /* '1000000000000000000000' */
+    cpy_r_r167 = CPyStatics[175]; /* 'grand' */
+    cpy_r_r168 = CPyStatics[314]; /* '1000000000000000000000' */
     cpy_r_r169 = CPyModule_decimal;
-    cpy_r_r170 = CPyStatics[183]; /* 'Decimal' */
+    cpy_r_r170 = CPyStatics[184]; /* 'Decimal' */
     cpy_r_r171 = CPyObject_GetAttr(cpy_r_r169, cpy_r_r170);
     if (unlikely(cpy_r_r171 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/units.py", "<module>", 26, CPyStatic_units___globals);
@@ -30363,10 +30408,10 @@ CPyL3: ;
         CPy_AddTraceback("faster_eth_utils/units.py", "<module>", 26, CPyStatic_units___globals);
         goto CPyL72;
     }
-    cpy_r_r175 = CPyStatics[175]; /* 'mether' */
-    cpy_r_r176 = CPyStatics[314]; /* '1000000000000000000000000' */
+    cpy_r_r175 = CPyStatics[176]; /* 'mether' */
+    cpy_r_r176 = CPyStatics[315]; /* '1000000000000000000000000' */
     cpy_r_r177 = CPyModule_decimal;
-    cpy_r_r178 = CPyStatics[183]; /* 'Decimal' */
+    cpy_r_r178 = CPyStatics[184]; /* 'Decimal' */
     cpy_r_r179 = CPyObject_GetAttr(cpy_r_r177, cpy_r_r178);
     if (unlikely(cpy_r_r179 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/units.py", "<module>", 27, CPyStatic_units___globals);
@@ -30380,10 +30425,10 @@ CPyL3: ;
         CPy_AddTraceback("faster_eth_utils/units.py", "<module>", 27, CPyStatic_units___globals);
         goto CPyL73;
     }
-    cpy_r_r183 = CPyStatics[176]; /* 'gether' */
-    cpy_r_r184 = CPyStatics[315]; /* '1000000000000000000000000000' */
+    cpy_r_r183 = CPyStatics[177]; /* 'gether' */
+    cpy_r_r184 = CPyStatics[316]; /* '1000000000000000000000000000' */
     cpy_r_r185 = CPyModule_decimal;
-    cpy_r_r186 = CPyStatics[183]; /* 'Decimal' */
+    cpy_r_r186 = CPyStatics[184]; /* 'Decimal' */
     cpy_r_r187 = CPyObject_GetAttr(cpy_r_r185, cpy_r_r186);
     if (unlikely(cpy_r_r187 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/units.py", "<module>", 28, CPyStatic_units___globals);
@@ -30397,10 +30442,10 @@ CPyL3: ;
         CPy_AddTraceback("faster_eth_utils/units.py", "<module>", 28, CPyStatic_units___globals);
         goto CPyL74;
     }
-    cpy_r_r191 = CPyStatics[177]; /* 'tether' */
-    cpy_r_r192 = CPyStatics[316]; /* '1000000000000000000000000000000' */
+    cpy_r_r191 = CPyStatics[178]; /* 'tether' */
+    cpy_r_r192 = CPyStatics[317]; /* '1000000000000000000000000000000' */
     cpy_r_r193 = CPyModule_decimal;
-    cpy_r_r194 = CPyStatics[183]; /* 'Decimal' */
+    cpy_r_r194 = CPyStatics[184]; /* 'Decimal' */
     cpy_r_r195 = CPyObject_GetAttr(cpy_r_r193, cpy_r_r194);
     if (unlikely(cpy_r_r195 == NULL)) {
         CPy_AddTraceback("faster_eth_utils/units.py", "<module>", 29, CPyStatic_units___globals);
@@ -30443,7 +30488,7 @@ CPyL3: ;
         goto CPyL53;
     }
     cpy_r_r200 = CPyStatic_units___globals;
-    cpy_r_r201 = CPyStatics[154]; /* 'units' */
+    cpy_r_r201 = CPyStatics[155]; /* 'units' */
     cpy_r_r202 = CPyDict_SetItem(cpy_r_r200, cpy_r_r201, cpy_r_r199);
     CPy_DECREF(cpy_r_r199);
     cpy_r_r203 = cpy_r_r202 >= 0;
@@ -30775,6 +30820,7 @@ int CPyGlobalsInit(void)
     CPyModule_re = Py_None;
     CPyModule_typing = Py_None;
     CPyModule_eth_typing = Py_None;
+    CPyModule_typing_extensions = Py_None;
     CPyModule_faster_eth_utils___conversions = Py_None;
     CPyModule_faster_eth_utils___crypto = Py_None;
     CPyModule_faster_eth_utils___hexadecimal = Py_None;
@@ -30814,6 +30860,7 @@ int CPyGlobalsInit(void)
     CPyModule_re = Py_None;
     CPyModule_typing = Py_None;
     CPyModule_eth_typing = Py_None;
+    CPyModule_typing_extensions = Py_None;
     CPyModule_faster_eth_utils___types = Py_None;
     CPyModule_faster_eth_utils___humanize = Py_None;
     CPyModule_builtins = Py_None;
@@ -30831,6 +30878,7 @@ int CPyGlobalsInit(void)
     CPyModule_collections___abc = Py_None;
     CPyModule_numbers = Py_None;
     CPyModule_typing = Py_None;
+    CPyModule_typing_extensions = Py_None;
     CPyModule_faster_eth_utils___units = Py_None;
     CPyModule_builtins = Py_None;
     CPyModule_decimal = Py_None;
@@ -30841,7 +30889,7 @@ int CPyGlobalsInit(void)
     return 0;
 }
 
-PyObject *CPyStatics[393];
+PyObject *CPyStatics[395];
 const char * const CPyLit_Str[] = {
     "\v\004type\000\ncomponents\001[\005count\004copy\002[]\006repeat\003abc\aMapping\004name",
     "\003\"Expected non-string sequence for \"\026\" component type: got \tTypeError",
@@ -30864,11 +30912,11 @@ const char * const CPyLit_Str[] = {
     "\002+Value must be any string, instead got type \017Unknown format ",
     "\002\034, attempted to normalize to #Both values must be valid addresses",
     "\006\005upper\aislower\aisupper\tisnumeric\033faster_eth_utils/address.py\005Final",
-    "\006\tTypeGuard\aAddress\nAnyAddress\017ChecksumAddress\nHexAddress\006HexStr",
-    "\004\rhexstr_if_str\034faster_eth_utils.conversions\radd_0x_prefix\ndecode_hex",
-    "\004\nencode_hex\020remove_0x_prefix\034faster_eth_utils.hexadecimal\bis_bytes",
-    "\006\ais_text\021(0x)\?[0-9a-f]{40}\nIGNORECASE\005ASCII\023_HEX_ADDRESS_REGEXP\0030x1",
-    "\003\0030x0\tbytearray\nmemoryview",
+    "\006\aAddress\nAnyAddress\017ChecksumAddress\nHexAddress\006HexStr\tTypeGuard",
+    "\003\021typing_extensions\rhexstr_if_str\034faster_eth_utils.conversions",
+    "\004\radd_0x_prefix\ndecode_hex\nencode_hex\020remove_0x_prefix",
+    "\004\034faster_eth_utils.hexadecimal\bis_bytes\ais_text\021(0x)\?[0-9a-f]{40}",
+    "\a\nIGNORECASE\005ASCII\023_HEX_ADDRESS_REGEXP\0030x1\0030x0\tbytearray\nmemoryview",
     "\001aUnsupported type: The primitive argument must be one of: bytes,bytearray, int or bool and not str",
     "\002\003hex\023Unsupported type: \'",
     "\0016\'. Must be one of: bool, str, bytes, bytearray or int.",
@@ -30928,22 +30976,22 @@ const char * const CPyLit_Int[] = {
 const double CPyLit_Float[] = {0};
 const double CPyLit_Complex[] = {0};
 const int CPyLit_Tuple[] = {
-    58, 2, 13, 39, 1, 61, 1, 64, 1, 11, 3, 8, 8, 8, 3, 67, 67, 67, 3,
-    68, 68, 68, 3, 338, 339, 340, 12, 71, 72, 73, 74, 43, 12, 75, 76, 77,
+    59, 2, 13, 39, 1, 61, 1, 64, 1, 11, 3, 8, 8, 8, 3, 67, 67, 67, 3,
+    68, 68, 68, 3, 339, 340, 341, 12, 71, 72, 73, 74, 43, 12, 75, 76, 77,
     78, 79, 80, 9, 82, 83, 84, 85, 86, 87, 88, 89, 90, 1, 92, 1, 63, 1,
-    340, 5, 71, 108, 109, 78, 79, 5, 110, 111, 112, 113, 114, 2, 115, 96,
-    4, 117, 118, 119, 120, 2, 122, 123, 1, 143, 4, 144, 75, 145, 78, 2,
-    114, 146, 2, 147, 148, 5, 117, 118, 119, 150, 120, 1, 151, 2, 184,
-    185, 1, 184, 3, 191, 191, 191, 1, 360, 1, 179, 3, 108, 78, 193, 2,
-    194, 151, 1, 154, 1, 205, 3, 210, 210, 210, 3, 212, 212, 212, 3, 213,
-    213, 213, 3, 367, 368, 369, 3, 222, 222, 222, 3, 223, 223, 223, 3,
-    371, 339, 372, 7, 71, 144, 72, 75, 225, 145, 193, 1, 123, 3, 243, 243,
-    243, 2, 376, 340, 4, 71, 245, 108, 109, 1, 114, 2, 151, 123, 6, 71,
-    108, 73, 266, 77, 78, 1, 255, 2, 268, 269, 2, 198, 270, 1, 271, 1,
-    292, 1, 71, 3, 302, 66, 66, 3, 303, 303, 303, 2, 388, 389, 6, 71, 74,
-    43, 77, 109, 78
+    341, 3, 71, 108, 78, 5, 109, 110, 111, 112, 113, 1, 114, 2, 116, 96,
+    4, 118, 119, 120, 121, 2, 123, 124, 1, 144, 4, 145, 75, 146, 78, 2,
+    113, 147, 2, 148, 149, 5, 118, 119, 120, 151, 121, 1, 152, 2, 185,
+    186, 1, 185, 3, 192, 192, 192, 1, 362, 1, 180, 3, 108, 78, 194, 2,
+    195, 152, 1, 155, 1, 206, 3, 211, 211, 211, 3, 213, 213, 213, 3, 214,
+    214, 214, 3, 369, 370, 371, 3, 223, 223, 223, 3, 224, 224, 224, 3,
+    373, 340, 374, 7, 71, 145, 72, 75, 226, 146, 194, 1, 124, 3, 244, 244,
+    244, 2, 378, 341, 3, 71, 246, 108, 1, 113, 2, 152, 124, 6, 71, 108,
+    73, 267, 77, 78, 1, 256, 2, 269, 270, 2, 199, 271, 1, 272, 1, 293, 1,
+    71, 3, 303, 66, 66, 3, 304, 304, 304, 2, 390, 391, 5, 71, 74, 43, 77,
+    78
 };
-const int CPyLit_FrozenSet[] = {1, 2, 26, 27};
+const int CPyLit_FrozenSet[] = {1, 2, 27, 26};
 CPyModule *CPyModule_faster_eth_utils___abi_internal = NULL;
 CPyModule *CPyModule_faster_eth_utils___abi;
 PyObject *CPyStatic_abi___globals;
@@ -30960,6 +31008,7 @@ CPyModule *CPyModule_faster_eth_utils___crypto;
 CPyModule *CPyModule_faster_eth_utils___address_internal = NULL;
 CPyModule *CPyModule_faster_eth_utils___address;
 PyObject *CPyStatic_address___globals;
+CPyModule *CPyModule_typing_extensions;
 CPyModule *CPyModule_faster_eth_utils___conversions_internal = NULL;
 CPyModule *CPyModule_faster_eth_utils___conversions;
 CPyModule *CPyModule_faster_eth_utils___hexadecimal_internal = NULL;

--- a/build/__native_internal_bce0bfc64ce5e845ec4a.h
+++ b/build/__native_internal_bce0bfc64ce5e845ec4a.h
@@ -6,7 +6,7 @@
 
 int CPyGlobalsInit(void);
 
-extern PyObject *CPyStatics[393];
+extern PyObject *CPyStatics[395];
 extern const char * const CPyLit_Str[];
 extern const char * const CPyLit_Bytes[];
 extern const char * const CPyLit_Int[];
@@ -30,6 +30,7 @@ extern CPyModule *CPyModule_faster_eth_utils___crypto;
 extern CPyModule *CPyModule_faster_eth_utils___address_internal;
 extern CPyModule *CPyModule_faster_eth_utils___address;
 extern PyObject *CPyStatic_address___globals;
+extern CPyModule *CPyModule_typing_extensions;
 extern CPyModule *CPyModule_faster_eth_utils___conversions_internal;
 extern CPyModule *CPyModule_faster_eth_utils___conversions;
 extern CPyModule *CPyModule_faster_eth_utils___hexadecimal_internal;

--- a/faster_eth_utils/address.py
+++ b/faster_eth_utils/address.py
@@ -2,9 +2,7 @@ import re
 from typing import (
     Any,
     Final,
-    TypeGuard,
     Union,
-    cast,
 )
 
 from eth_typing import (
@@ -13,6 +11,9 @@ from eth_typing import (
     ChecksumAddress,
     HexAddress,
     HexStr,
+)
+from typing_extensions import (
+    TypeGuard,
 )
 
 from .conversions import (

--- a/faster_eth_utils/hexadecimal.py
+++ b/faster_eth_utils/hexadecimal.py
@@ -6,11 +6,13 @@ from typing import (
     Any,
     AnyStr,
     Final,
-    TypeGuard,
 )
 
 from eth_typing import (
     HexStr,
+)
+from typing_extensions import (
+    TypeGuard,
 )
 
 from .types import (

--- a/faster_eth_utils/types.py
+++ b/faster_eth_utils/types.py
@@ -5,8 +5,11 @@ from typing import (
     List,
     Literal,
     Tuple,
-    TypeGuard,
     Union,
+)
+
+from typing_extensions import (
+    TypeGuard,
 )
 
 bytes_types = (bytes, bytearray)


### PR DESCRIPTION
### What was wrong?

Related to Issue #
Closes #

### How was it fixed?

### Todo:

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/eth-utils/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](<>)
