### PR TITLE
feat: include eth-typing as build dep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,11 @@
 [build-system]
-requires = ["setuptools", "wheel", "mypy[mypyc]>=1.14.1,<1.17.1"]
+requires = [
+  "setuptools",
+  "wheel",
+  "mypy[mypyc]>=1.14.1,<1.17.1",
+  "eth-hash>=0.3.1",
+  "eth-typing>=3.0.0",
+]
 
 [tool.autoflake]
 exclude = "__init__.py"


### PR DESCRIPTION
This ensures the compiler has access to its type hint information when we build wheels for release

### What was wrong?

Related to Issue #
Closes #

### How was it fixed?

### Todo:

- [ ] Clean up commit history
- [ ] Add or update documentation related to these changes
- [ ] Add entry to the [release notes](https://github.com/ethereum/eth-utils/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](<>)
