### PR TITLE
fix(mypy): fix new type error on python3.14

### DIFF
--- a/faster_eth_utils/pydantic.py
+++ b/faster_eth_utils/pydantic.py
@@ -81,7 +81,7 @@ class CamelModel(BaseModel):
     )
 
     @classmethod
-    def model_json_schema(
+    def model_json_schema(  # type: ignore [override]
         cls,
         by_alias: bool = True,
         ref_template: str = DEFAULT_REF_TEMPLATE,


### PR DESCRIPTION
This prevents certain downstream libs from building properly on 3.14
