### PR TITLE
fix(test): generate valid tox env names

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -20,14 +20,14 @@ concurrency:
 
 jobs:
   tox:
-    name: Test (${{ matrix.jobtype }}, ${{ matrix.pyversion}}, ${{ matrix.os }}, ${{ matrix.architecture }})
+    name: Test (${{ matrix.jobtype }}, 3.${{ matrix.pyminor }}, ${{ matrix.os }}, ${{ matrix.architecture }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         jobtype: [core, wheel]
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        pyversion: [ "3.10", "3.11", "3.12", "3.13", "3.13t", "3.14", "3.14t" ]
+        pyminor: [ "10", "11", "12", "13", "13t", "14", "14t" ]
         architecture: [x64, x86]
         exclude:
           # Exclude x86 (32-bit) builds for macos, which doesn't support 32-bit at all
@@ -36,7 +36,7 @@ jobs:
       # limit parallelism for cronjob, otherwise blast it
       max-parallel: ${{ github.event_name == 'schedule' && 4 || 1000 }}
     env:
-      TOXENV: py${{ matrix.pyversion }}-${{ matrix.jobtype }}
+      TOXENV: py3${{ matrix.pyminor }}-${{ matrix.jobtype }}
       TOX_RECREATE_FLAG: ${{ github.event_name == 'schedule' && '-r' || '' }}
       IS_UBUNTU_32BIT: ${{ matrix.os == 'ubuntu-latest' && matrix.architecture == 'x86' }}
     
@@ -52,7 +52,7 @@ jobs:
         if: ${{ env.IS_UBUNTU_32BIT == 'true' }}
         uses: addnab/docker-run-action@v3
         with:
-          image: i386/python:${{ matrix.pyversion }}
+          image: i386/python:3.${{ matrix.pyminor }}
           shell: bash
           options: -v ${{ github.workspace }}:/workspace -w /workspace
           run: |
@@ -61,14 +61,14 @@ jobs:
             python -m tox -e ${{ env.TOXENV }} ${{ env.TOX_RECREATE_FLAG }}
         # There are no prebuilt 32-bit freethreaded Python containers at the time of this commit, but
         # we will keep these runners so they will activate on their own whenever such containers exist
-        continue-on-error: ${{ matrix.pyversion == '3.13t' || matrix.pyversion == '3.14t' }}
+        continue-on-error: ${{ matrix.pyminor == '13t' || matrix.pyminor == '14t' }}
 
       # No architecture specified for MacOS
       - name: Set up Python (macos)
         if: ${{ matrix.os == 'macos-latest' }}
         uses: actions/setup-python@v6
         with:
-          python-version: ${{ matrix.pyversion }}
+          python-version: 3.${{ matrix.pyminor }}
           cache: pip
           cache-dependency-path: |
             setup.py
@@ -80,7 +80,7 @@ jobs:
         if: ${{ matrix.os != 'macos-latest' && env.IS_UBUNTU_32BIT != 'true' }}
         uses: actions/setup-python@v6
         with:
-          python-version: ${{ matrix.pyversion }}
+          python-version: 3.${{ matrix.pyminor }}
           architecture: ${{ matrix.architecture }}
           cache: pip
           cache-dependency-path: |
@@ -108,7 +108,7 @@ jobs:
           path: |
             .tox
             .hypothesis
-          key: ${{ runner.os }}-tox-${{ hashFiles('pyproject.toml', 'setup.py', 'tox.ini') }}-${{ matrix.pyversion }}-${{ matrix.architecture }}-${{ matrix.jobtype }}
+          key: ${{ runner.os }}-tox-${{ hashFiles('pyproject.toml', 'setup.py', 'tox.ini') }}-3.${{ matrix.pyminor }}-${{ matrix.architecture }}-${{ matrix.jobtype }}
           save-always: ${{ env.TOX_RECREATE_FLAG == '-r' }}
 
       - name: Run tox


### PR DESCRIPTION
The tox workflow has been constructing `TOXENV` directly from dotted Python versions, producing env names that do not exist in `tox.ini`. This makes jobs fail before they reach the actual test/build logic.

- replace dotted `matrix.pyversion` with compact `matrix.pyminor` in the tox workflow
- generate tox envs like `py310-core` instead of invalid names like `py3.10-core`
- keep setup-python and i386 Docker image tags using dotted Python versions via `3.${{ matrix.pyminor }}`