### PR TITLE
fix(test): install built wheel in tox smoke test

### DIFF
--- a/scripts/ci/smoke_test_built_wheel.py
+++ b/scripts/ci/smoke_test_built_wheel.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+BUILD_DIR = PROJECT_ROOT / "build"
+DIST_DIR = PROJECT_ROOT / "dist"
+WHEEL_PATTERN = "faster_eth_utils-*.whl"
+PACKAGE_IMPORT = "faster_eth_utils"
+
+
+def run_python(*args: str, cwd: Path = PROJECT_ROOT) -> None:
+    subprocess.run((sys.executable, *args), cwd=cwd, check=True)
+
+
+def clean_build_artifacts() -> None:
+    for path in (BUILD_DIR, DIST_DIR):
+        if path.exists():
+            shutil.rmtree(path)
+
+
+def find_built_wheel() -> Path:
+    wheels = sorted(DIST_DIR.glob(WHEEL_PATTERN))
+    if len(wheels) == 1:
+        return wheels[0]
+
+    found = ", ".join(wheel.name for wheel in wheels) or "none"
+    raise SystemExit(
+        f"Expected exactly one {WHEEL_PATTERN} in {DIST_DIR}, found {found}."
+    )
+
+
+def main() -> None:
+    clean_build_artifacts()
+    run_python("-m", "build")
+
+    wheel = find_built_wheel()
+    print(f"Installing wheel: {wheel.name}")
+    run_python(
+        "-m",
+        "pip",
+        "install",
+        "--upgrade",
+        str(wheel),
+        "--progress-bar",
+        "off",
+    )
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        run_python("-c", f"import {PACKAGE_IMPORT}", cwd=Path(tmpdir))
+
+
+if __name__ == "__main__":
+    main()

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,6 @@
 envlist=
     py{310,311,312,313,313t,314,314t}-core
     py{310,311,312,313,313t,314,314t}-wheel
-    windows-wheel
 
 [flake8]
 exclude=venv*,.tox,docs,build
@@ -18,8 +17,6 @@ usedevelop=True
 install_command=python -m pip install {opts} {packages}
 commands=
     core: pytest {posargs:tests/core}
-basepython=
-    windows-wheel: python
 extras=
     test
     docs
@@ -31,29 +28,8 @@ deps=
 deps=
     wheel
     build[virtualenv]
-allowlist_externals=
-    /bin/rm
-    /bin/bash
 commands=
     python -m pip install --upgrade pip
-    /bin/rm -rf build dist
-    python -m build
-    /bin/bash -c 'python -m pip install --upgrade "$(ls dist/faster_eth_utils-*-py3-none-any.whl)" --progress-bar off'
-    python -c "import faster_eth_utils"
+    python scripts/ci/smoke_test_built_wheel.py
 
-skip_install=true
-
-[testenv:windows-wheel]
-deps=
-    wheel
-    build[virtualenv]
-allowlist_externals=
-    bash.exe
-commands=
-    python --version
-    python -m pip install --upgrade pip
-    bash.exe -c "rm -rf build dist"
-    python -m build
-    bash.exe -c 'python -m pip install --upgrade "$(ls dist/faster_eth_utils-*-py3-none-any.whl)" --progress-bar off'
-    python -c "import faster_eth_utils"
 skip_install=true


### PR DESCRIPTION
## Summary
- replace the hard-coded `py3-none-any` wheel glob with a small cross-platform wheel smoke-test helper
- install the actual wheel produced by `python -m build`, including platform wheels like `cp311-cp311-linux_x86_64`
- remove shell-specific cleanup/install commands from the wheel tox envs

## Rationale
The wheel tox jobs build mypyc extension wheels, so the artifact is platform-specific rather than `py3-none-any`. The old tox command searched only for a universal wheel, failed to install the built artifact, and then the import check fell back to local source without runtime dependencies.