### PR TITLE
docs: clarify compiled runtime contract for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,8 @@
 
 All agents must follow these rules:
 
+faster-eth-utils is always compiled. PyPI wheels are compiled, setup compiles the project, and tests/CI must validate compiled extensions. Do not invent or reason from an interpreted `.py` runtime path; tracked `.py` files are mypyc source inputs.
+
 1) Fully test your changes before submitting a PR (run the full suite or all relevant tests).
 2) PR titles must be descriptive and follow Conventional Commits-style prefixes:
    - Common: `feat:`, `fix:`, `chore:`, `refactor:`, `docs:`, `test:`, `perf:`


### PR DESCRIPTION
## Summary
- Adds an upfront AGENTS.md note that faster-eth-utils is always compiled and tracked .py files are mypyc source inputs.

## Rationale
- Prevents agents from inferring an interpreted .py runtime path in this mypyc package.

## Details
- Adds one concise compiled-runtime paragraph near the top of AGENTS.md.