### PR TITLE
fix(ci): package bundled network JSON data explicitly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -136,7 +136,10 @@ setup(
     keywords="ethereum",
     packages=find_packages(exclude=["scripts", "scripts.*", "tests", "tests.*"]),
     ext_modules=ext_modules,
-    package_data={"faster_eth_utils": ["py.typed"]},
+    package_data={
+        "faster_eth_utils": ["py.typed"],
+        "faster_eth_utils.__json": ["*.json"],
+    },
     classifiers=[
         "Intended Audience :: Developers",
         "Natural Language :: English",


### PR DESCRIPTION
## Summary

Make the bundled `faster_eth_utils.__json` directory an explicit internal package and declare its JSON data in `package_data`.

## Rationale

Setuptools recognizes `faster_eth_utils.__json` as an importable package-like directory, but the current `find_packages()` configuration does not include it because it has no `__init__.py`. During release builds this produces a “Package would be ignored” warning for the bundled `eth_networks.json` resource.

## Details

- Add `faster_eth_utils/__json/__init__.py` so `find_packages()` includes the internal resource package.
- Add `faster_eth_utils.__json: ["*.json"]` to `package_data`.
- Keep the existing `MANIFEST.in` JSON include for sdist packaging.
- Preserve the existing runtime JSON loading behavior in `network.py`.
- Verified by building release artifacts, checking metadata, inspecting the wheel contents, and running `tests/core` against the installed compiled wheel.